### PR TITLE
Fix incorrect time exceedance check

### DIFF
--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -92,9 +92,9 @@ public class MiLoGChecker implements IChecker {
         TimeSpan totalWorkingTime = fullDoc.getTotalWorkTime();
         
         //Vacation and transfer corrected time
-        TimeSpan correctedMaxWorkingTime = maxWorkingTime.subtract(fullDoc.getVacation())
-                .subtract(fullDoc.getPredTransfer())
-                .add(fullDoc.getSuccTransfer());
+        TimeSpan correctedMaxWorkingTime = maxWorkingTime.add(fullDoc.getSuccTransfer())
+                .subtract(fullDoc.getVacation())
+                .subtract(fullDoc.getPredTransfer());
         
         if (totalWorkingTime.compareTo(correctedMaxWorkingTime) > 0) {
             errors.add(new CheckerError(CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage()));

--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -85,9 +85,18 @@ public class MiLoGChecker implements IChecker {
      * Checks whether maximum working time was exceeded.
      */
     protected void checkTotalTimeExceedance() {
+        //Legal maximum working time per month
         TimeSpan maxWorkingTime = fullDoc.getProfession().getMaxWorkingTime();
         
-        if (fullDoc.getTotalWorkTime().compareTo(maxWorkingTime) > 0) {
+        //Sum of all daily working times (without pauses!)
+        TimeSpan totalWorkingTime = fullDoc.getTotalWorkTime();
+        
+        //Vacation and transfer corrected time
+        TimeSpan correctedMaxWorkingTime = maxWorkingTime.subtract(fullDoc.getVacation())
+                .subtract(fullDoc.getPredTransfer())
+                .add(fullDoc.getSuccTransfer());
+        
+        if (totalWorkingTime.compareTo(correctedMaxWorkingTime) > 0) {
             errors.add(new CheckerError(CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage()));
             result = CheckerReturn.INVALID;
         }

--- a/src/main/java/data/TimeSheet.java
+++ b/src/main/java/data/TimeSheet.java
@@ -26,7 +26,17 @@ public class TimeSheet {
      */
     public TimeSheet(Employee employee, Profession profession, YearMonth yearMonth, Entry[] entries, TimeSpan vacation,
             TimeSpan succTransfer, TimeSpan predTransfer) {
-        this.employee = employee;
+        
+        /*
+         * This check has to be done in order to guarantee that the corrected max working time
+         * (corrected => taking vacation and transfer into account) is not negative.
+         */
+        if (profession.getMaxWorkingTime().add(succTransfer).compareTo(predTransfer.add(vacation)) < 0) {
+            throw new IllegalArgumentException("Sum of predTransfer and vacation cannot be greater "
+                    + "than maxWorkingTime and succTransfer.");
+        }
+        
+            this.employee = employee;
         this.profession = profession;
         this.yearMonth = yearMonth;
         this.vacation = vacation;

--- a/src/main/java/data/TimeSheet.java
+++ b/src/main/java/data/TimeSheet.java
@@ -33,7 +33,7 @@ public class TimeSheet {
          */
         if (profession.getMaxWorkingTime().add(succTransfer).compareTo(predTransfer.add(vacation)) < 0) {
             throw new IllegalArgumentException("Sum of predTransfer and vacation cannot be greater "
-                    + "than maxWorkingTime and succTransfer.");
+                    + "than sum of maxWorkingTime and succTransfer.");
         }
         
             this.employee = employee;

--- a/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
@@ -119,6 +119,54 @@ public class MiLoGCheckerTotalTimeExceedanceTest {
     }
     
     @Test
+    public void testNoExceedanceSuccTransferUpperBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan succTransfer = new TimeSpan(4, 0);
+        int hoursToWork = 18;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, zeroTs, succTransfer, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.VALID, checker.getResult());
+        assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
+    public void testExceedanceSuccTransferLowerBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan succTransfer = new TimeSpan(3, 59);
+        int hoursToWork = 18;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, zeroTs, succTransfer, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
     public void testNoExceedanceVacationUpperBound() {
         //Test values
         TimeSpan maxWorkTime = new TimeSpan(14, 0);

--- a/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
@@ -119,6 +119,202 @@ public class MiLoGCheckerTotalTimeExceedanceTest {
     }
     
     @Test
+    public void testNoExceedanceVacationUpperBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan vacation = new TimeSpan(1, 0);
+        int hoursToWork = 13;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.VALID, checker.getResult());
+        assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
+    public void testExceedanceCausedByVacationLowerBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan vacation = new TimeSpan(0, 1);
+        int hoursToWork = 14;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
+    public void testExceedanceCausedByVacationHours() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan vacation = new TimeSpan(2, 0);
+        int hoursToWork = 13;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
+    public void testExceedanceCausedByPredTransferHours() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan predTransfer = new TimeSpan(2, 0);
+        int hoursToWork = 13;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, zeroTs, zeroTs, predTransfer);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
+    public void testExceedanceCausedByPredTransferLowerBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan predTransfer = new TimeSpan(0, 1);
+        int hoursToWork = 14;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, zeroTs, zeroTs, predTransfer);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
+    public void testExceedancePredTransferVacationLowerBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan predTransfer = new TimeSpan(1, 30);
+        TimeSpan vacation = new TimeSpan(2, 31);
+        int hoursToWork = 10;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, zeroTs, predTransfer);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_EXCEEDANCE.getErrorMessage())));
+    }
+    
+    @Test
+    public void testNoExceedancePredTransferVacationUpperBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan predTransfer = new TimeSpan(1, 30);
+        TimeSpan vacation = new TimeSpan(2, 30);
+        int hoursToWork = 10;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, zeroTs, predTransfer);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.VALID, checker.getResult());
+        assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
+    public void testNoExceedancePredSuccTransferVacationLowerBound() {
+        //Test values
+        TimeSpan maxWorkTime = new TimeSpan(14, 0);
+        TimeSpan succTransfer = new TimeSpan(4, 0);
+        TimeSpan predTransfer = new TimeSpan(1, 30);
+        TimeSpan vacation = new TimeSpan(2, 30);
+        int hoursToWork = 14;
+        int minutesToWork = 0;
+        
+        //Checker initialization
+        Entry entry1 = new Entry("Test 1", LocalDate.of(2019, 11, 22), 
+                new TimeSpan(0, 0), new TimeSpan(hoursToWork, minutesToWork), new TimeSpan(0, 0));
+        Entry[] entries = {entry1};
+        Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, maxWorkTime, 10.31);
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, profession, YEAR_MONTH, entries, vacation, succTransfer, predTransfer);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        //Executions
+        checker.checkTotalTimeExceedance();
+        
+        //Assertions
+        assertEquals(CheckerReturn.VALID, checker.getResult());
+        assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
     public void testExceedanceRandomHoursWithoutPause() {
         //Random
         Random rand = new Random();

--- a/src/test/java/data/TimeSheetCommonTest.java
+++ b/src/test/java/data/TimeSheetCommonTest.java
@@ -1,0 +1,49 @@
+package data;
+
+import static org.junit.Assert.*;
+
+import java.time.YearMonth;
+
+import org.junit.Test;
+
+public class TimeSheetCommonTest {
+
+    @SuppressWarnings("unused")
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidTransferVacation() {
+        ////Test values
+        TimeSpan maxWorkingTime = new TimeSpan(40, 0);
+        TimeSpan vacation = new TimeSpan(10, 0);
+        TimeSpan predTransfer = new TimeSpan(60, 0);
+        TimeSpan succTransfer = new TimeSpan(20, 0);
+        
+        ////TimeSheet initialization
+        Employee employee = new Employee("Max Mustermann", 1234567);
+        Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
+        YearMonth yearMonth = YearMonth.of(2019, 11);
+        Entry[] entries = null;
+        TimeSheet timeSheet = new TimeSheet(employee, profession, yearMonth, entries, vacation, succTransfer, predTransfer);
+        
+        ////Assertions
+    }
+
+    @Test
+    public void testValidTransferVacationUpperBound() {
+        ////Test values
+        TimeSpan maxWorkingTime = new TimeSpan(40, 0);
+        TimeSpan vacation = new TimeSpan(10, 0);
+        TimeSpan predTransfer = new TimeSpan(50, 0);
+        TimeSpan succTransfer = new TimeSpan(20, 0);
+        
+        ////TimeSheet initialization
+        Employee employee = new Employee("Max Mustermann", 1234567);
+        Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
+        YearMonth yearMonth = YearMonth.of(2019, 11);
+        Entry[] entries = null;
+        TimeSheet timeSheet = new TimeSheet(employee, profession, yearMonth, entries, vacation, succTransfer, predTransfer);
+        
+        ////Assertions
+        assertTrue(timeSheet != null);
+    }
+
+}


### PR DESCRIPTION
As stated out by #39 the check for total time exceedance or monthly time exceedance respectively, does not take vacation, predecessor- and successor-transfer into account. Therefore I did the following changes in order to fix this issue:
- Modified check for total time exceedance taking vacation and transfers into account. This was done by calculating a corrected maximum working time. This new corrected time is the old max working time...
... **minus vacation** (because vacation is part of the legal max working time given by profession).
... **minus predecessor-transfer** (because this is nothing different than daily working time, coming from another month).
... **plus successor-transfer** (because this is the time you do not want to add to this but rather transfer to your next time sheet).
- Added JUnit tests especially for edge cases

For this reason, this PR fixes #39.