### PR TITLE
Sort TimeSheet Entries

### DIFF
--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -1,21 +1,16 @@
 package checker;
 
 import data.Entry;
-import data.Tuple;
 import data.TimeSheet;
 import data.TimeSpan;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import checker.holiday.HolidayFetchException;
 import checker.holiday.IHolidayChecker;
 import checker.holiday.GermanState;
@@ -197,7 +192,7 @@ public class MiLoGChecker implements IChecker {
      * Checks whether the number of entries exceeds the maximum number of rows of the template document.
      */
     protected void checkRowNumExceedance() {
-        if (fullDoc.getEntries().length > MAX_ROW_NUM) {
+        if (fullDoc.getEntries().size() > MAX_ROW_NUM) {
             errors.add(new CheckerError(CheckerErrorMessage.ROWNUM_EXCEEDENCE.getErrorMessage()));
             result = CheckerReturn.INVALID;
         }
@@ -217,20 +212,14 @@ public class MiLoGChecker implements IChecker {
      * Checks whether times of different entries in the time sheet overlap.
      */
     protected void checkTimeOverlap() {
-        if (fullDoc.getEntries().length == 0) {
+        List<Entry> entries = fullDoc.getEntries();
+        if (entries.size() == 0) {
             return;
         }
         
-        List<Tuple<LocalDateTime, LocalDateTime>> times = Arrays.asList(fullDoc.getEntries()).stream().map(
-            entry -> new Tuple<LocalDateTime, LocalDateTime>(
-                entry.getDate().atTime(entry.getStart().getHour(), entry.getStart().getMinute()),
-                entry.getDate().atTime(entry.getEnd().getHour(), entry.getEnd().getMinute())
-            )
-        ).collect(Collectors.toList());
-        times.sort((a, b) -> a.getFirst().compareTo(b.getFirst()));
-        
-        for (int i = 0; i < times.size() - 1; i++) {
-            if (times.get(i).getSecond().isAfter(times.get(i + 1).getFirst())) {
+        for (int i = 0; i < entries.size() - 1; i++) {
+            if (entries.get(i).getDate().equals(entries.get(i + 1).getDate()) &&
+                    entries.get(i).getEnd().compareTo(entries.get(i + 1).getStart()) > 0) {
                 errors.add(new CheckerError(CheckerErrorMessage.TIME_OVERLAP.getErrorMessage()));
                 result = CheckerReturn.INVALID;
                 return;

--- a/src/main/java/data/Entry.java
+++ b/src/main/java/data/Entry.java
@@ -5,10 +5,10 @@ import java.time.LocalDate;
 /**
  * An entry represents a continuous work interval of an {@link Employee}.
  */
-public class Entry {
-    private String action;
-    private LocalDate date;
-    private TimeSpan start, end, pause;
+public class Entry implements Comparable<Entry> {
+    private final String action;
+    private final LocalDate date;
+    private final TimeSpan start, end, pause;
 
     /**
      * Constructs a new instance of {@link Entry}
@@ -85,5 +85,16 @@ public class Entry {
         
         return workingTime;
     }
-    
+
+    /**
+     * Compare by date and start time.
+     */
+    @Override
+    public int compareTo(Entry o) {
+        if (this.date.compareTo(o.getDate()) != 0) {
+            return this.date.compareTo(o.getDate());
+        } else {
+            return this.start.compareTo(o.getStart());
+        }
+    }
 }

--- a/src/main/java/data/TimeSheet.java
+++ b/src/main/java/data/TimeSheet.java
@@ -2,6 +2,9 @@ package data;
 
 import java.time.Month;
 import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A time sheet represents a whole month of work done by an {@link Employee}.
@@ -11,7 +14,7 @@ public class TimeSheet {
     private final Profession profession;
     private final YearMonth yearMonth;
     private final TimeSpan vacation, succTransfer, predTransfer;
-    private final Entry[] entries;
+    private final List<Entry> entries;
     
     /**
      * Constructs a new instance of {@code TimeSheet}.
@@ -36,13 +39,16 @@ public class TimeSheet {
                     + "than sum of maxWorkingTime and succTransfer.");
         }
         
-            this.employee = employee;
+        this.employee = employee;
         this.profession = profession;
         this.yearMonth = yearMonth;
         this.vacation = vacation;
         this.succTransfer = succTransfer;
         this.predTransfer = predTransfer;
-        this.entries = entries;
+        
+        List<Entry> entryList = Arrays.asList(entries);
+        Collections.sort(entryList);
+        this.entries = Collections.unmodifiableList(entryList);
     }
 
     /**
@@ -63,9 +69,10 @@ public class TimeSheet {
 
     /**
      * Gets all entries associated with a {@link TimeSheet}.
+     * The list of entries is sorted as specified in {@link Entry}.
      * @return The entries.
      */
-    public Entry[] getEntries() {
+    public List<Entry> getEntries() {
         return entries;
     }
     

--- a/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
@@ -69,7 +69,7 @@ public class MiLoGCheckerRowNumExceedanceTest {
         checker.checkRowNumExceedance();
         
         ////Assertions
-        assertTrue(numberOfEntries == fullDoc.getEntries().length);
+        assertTrue(numberOfEntries == fullDoc.getEntries().size());
         assertEquals(CheckerReturn.VALID, checker.getResult());
         assertTrue(checker.getErrors().isEmpty());
     }
@@ -98,7 +98,7 @@ public class MiLoGCheckerRowNumExceedanceTest {
         checker.checkRowNumExceedance();
         
         ////Assertions
-        assertTrue(numberOfEntries == fullDoc.getEntries().length);
+        assertTrue(numberOfEntries == fullDoc.getEntries().size());
         assertEquals(CheckerReturn.INVALID, checker.getResult());
         assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.ROWNUM_EXCEEDENCE.getErrorMessage())));
     }
@@ -130,8 +130,8 @@ public class MiLoGCheckerRowNumExceedanceTest {
         checker.checkRowNumExceedance();
         
         ////Assertions
-        assertTrue(numberOfEntries == fullDoc.getEntries().length);
-        if (fullDoc.getEntries().length > MiLoGChecker.getMaxEntries()) {
+        assertTrue(numberOfEntries == fullDoc.getEntries().size());
+        if (fullDoc.getEntries().size() > MiLoGChecker.getMaxEntries()) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
             assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.ROWNUM_EXCEEDENCE.getErrorMessage())));
         } else {

--- a/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
+++ b/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
@@ -99,6 +99,41 @@ public class MiLoGCheckerTimeOverlapTest {
     }
     
     @Test
+    public void testMultipleEntriesWithoutOverlapUnsorted() {
+        ////Test values
+        TimeSpan start0 = new TimeSpan(8, 0);
+        TimeSpan end0 = new TimeSpan(12, 0);
+        TimeSpan pause0 = zeroTs;
+        LocalDate date0 = LocalDate.of(2019, 11, 22);
+        Entry entry0 = new Entry("Test 0", date0, start0, end0, pause0);
+        
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = zeroTs;
+        LocalDate date1 = LocalDate.of(2019, 11, 22);
+        Entry entry1 = new Entry("Test 1", date1, start1, end1, pause1);
+        
+        TimeSpan start2 = new TimeSpan(8, 0);
+        TimeSpan end2 = new TimeSpan(12, 0);
+        TimeSpan pause2 = zeroTs;
+        LocalDate date2 = LocalDate.of(2019, 11, 25);
+        Entry entry2 = new Entry("Test 2", date2, start2, end2, pause2);
+        
+        Entry[] entries = {entry1, entry2, entry0};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
+        
+        ////Checker initialization
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Execution
+        checker.checkTimeOverlap();
+        
+        ////Assertions
+        assertEquals(CheckerReturn.VALID, checker.getResult());
+        assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
     public void testMultipleEntriesWithoutOverlapTouching() {
         ////Test values
         TimeSpan start0 = new TimeSpan(8, 0);
@@ -155,6 +190,41 @@ public class MiLoGCheckerTimeOverlapTest {
         Entry entry2 = new Entry("Test 2", date2, start2, end2, pause2);
         
         Entry[] entries = {entry0, entry1, entry2};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
+        
+        ////Checker initialization
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Execution
+        checker.checkTimeOverlap();
+        
+        ////Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage())));
+    }
+    
+    @Test
+    public void testMultipleEntriesWithOverlapUnsorted() {
+        ////Test values
+        TimeSpan start0 = new TimeSpan(8, 0);
+        TimeSpan end0 = new TimeSpan(12, 0);
+        TimeSpan pause0 = zeroTs;
+        LocalDate date0 = LocalDate.of(2019, 11, 22);
+        Entry entry0 = new Entry("Test 0", date0, start0, end0, pause0);
+        
+        TimeSpan start1 = new TimeSpan(11, 0);
+        TimeSpan end1 = new TimeSpan(13, 0);
+        TimeSpan pause1 = zeroTs;
+        LocalDate date1 = LocalDate.of(2019, 11, 22);
+        Entry entry1 = new Entry("Test 1", date1, start1, end1, pause1);
+        
+        TimeSpan start2 = new TimeSpan(8, 0);
+        TimeSpan end2 = new TimeSpan(12, 0);
+        TimeSpan pause2 = zeroTs;
+        LocalDate date2 = LocalDate.of(2019, 11, 25);
+        Entry entry2 = new Entry("Test 2", date2, start2, end2, pause2);
+        
+        Entry[] entries = {entry1, entry2, entry0};
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         
         ////Checker initialization

--- a/src/test/java/data/EntryCompareToTest.java
+++ b/src/test/java/data/EntryCompareToTest.java
@@ -1,0 +1,179 @@
+package data;
+
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+public class EntryCompareToTest {
+
+    @Test
+    public void testCompareToSmallerDate() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 17);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) < 0);
+    }
+    
+    @Test
+    public void testCompareToGreaterDate() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 15);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) > 0);
+    }
+    
+    @Test
+    public void testCompareToSmallerHour() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(15, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) < 0);
+    }
+    
+    @Test
+    public void testCompareToGreaterHour() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(13, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) > 0);
+    }
+    
+    @Test
+    public void testCompareToSmallerMinute() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(14, 10);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) < 0);
+    }
+    
+    @Test
+    public void testCompareToGreaterMinute() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 10);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) > 0);
+    }
+    
+    @Test
+    public void testCompareToEqual() {
+        String action0 = "Test";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(18, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test";
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 30);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) == 0);
+    }
+    
+    @Test
+    public void testCompareToEqualDateHourMinute() {
+        String action0 = "Test 1";
+        TimeSpan start0 = new TimeSpan(14, 0);
+        TimeSpan end0 = new TimeSpan(19, 0);
+        TimeSpan pause0 = new TimeSpan(0, 30);
+        LocalDate date0 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry0 = new Entry(action0, date0, start0, end0, pause0);
+        
+        String action1 = "Test 2";
+        TimeSpan start1 = new TimeSpan(14, 0);
+        TimeSpan end1 = new TimeSpan(18, 0);
+        TimeSpan pause1 = new TimeSpan(0, 15);
+        LocalDate date1 = LocalDate.of(2019, 11, 16);
+        
+        Entry entry1 = new Entry(action1, date1, start1, end1, pause1);
+        
+        assertTrue(entry0.compareTo(entry1) == 0);
+    }
+    
+}

--- a/src/test/java/data/TimeSheetCommonTest.java
+++ b/src/test/java/data/TimeSheetCommonTest.java
@@ -21,7 +21,7 @@ public class TimeSheetCommonTest {
         Employee employee = new Employee("Max Mustermann", 1234567);
         Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
         YearMonth yearMonth = YearMonth.of(2019, 11);
-        Entry[] entries = null;
+        Entry[] entries = new Entry[0];
         TimeSheet timeSheet = new TimeSheet(employee, profession, yearMonth, entries, vacation, succTransfer, predTransfer);
         
         ////Assertions
@@ -39,7 +39,7 @@ public class TimeSheetCommonTest {
         Employee employee = new Employee("Max Mustermann", 1234567);
         Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
         YearMonth yearMonth = YearMonth.of(2019, 11);
-        Entry[] entries = null;
+        Entry[] entries = new Entry[0];
         TimeSheet timeSheet = new TimeSheet(employee, profession, yearMonth, entries, vacation, succTransfer, predTransfer);
         
         ////Assertions


### PR DESCRIPTION
- make Entry immutable and comparable
- sort entries in TimeSheet constructor and make entry list unmodifiable
- change time overlap check (sorting is unnecessary)

resolves #44