### PR TITLE
Additional info on checker errors

### DIFF
--- a/src/main/java/checker/CheckerError.java
+++ b/src/main/java/checker/CheckerError.java
@@ -15,9 +15,10 @@ public class CheckerError {
     /**
      * Constructs a new {@link CheckerError} instance.
      * @param errorMsg - associated with the occurred error.
+     * @param args - Arguments referenced by the format specifiers in the errorMsg format string. 
      */
-    public CheckerError(String errorMsg) {
-        this.errorMsg = errorMsg;
+    public CheckerError(String errorMsg, Object... args) {
+        this.errorMsg = String.format(errorMsg, args);
     }
     
     /**

--- a/src/test/java/checker/MiLoGCheckerCheckTest.java
+++ b/src/test/java/checker/MiLoGCheckerCheckTest.java
@@ -56,9 +56,12 @@ public class MiLoGCheckerCheckTest {
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         MiLoGChecker checker = new MiLoGChecker(fullDoc);
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.check());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -75,9 +78,12 @@ public class MiLoGCheckerCheckTest {
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         MiLoGChecker checker = new MiLoGChecker(fullDoc);
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.check());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -94,8 +100,11 @@ public class MiLoGCheckerCheckTest {
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         MiLoGChecker checker = new MiLoGChecker(fullDoc);
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.check());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
 }

--- a/src/test/java/checker/MiLoGCheckerDayTimeBoundsTest.java
+++ b/src/test/java/checker/MiLoGCheckerDayTimeBoundsTest.java
@@ -84,9 +84,12 @@ public class MiLoGCheckerDayTimeBoundsTest {
         ////Execution
         checker.checkDayTimeBounds();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -135,9 +138,12 @@ public class MiLoGCheckerDayTimeBoundsTest {
         ////Execution
         checker.checkDayTimeBounds();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -180,10 +186,13 @@ public class MiLoGCheckerDayTimeBoundsTest {
         ////Execution
         checker.checkDayTimeBounds();
         
+        ////Expectation (on error)
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         if (start.compareTo(CHECKER_WORKDAY_LOWER_BOUND) < 0) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
-            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage())));
+            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
         } else {
             assertEquals(CheckerReturn.VALID, checker.getResult());
             assertTrue(checker.getErrors().isEmpty());
@@ -209,13 +218,46 @@ public class MiLoGCheckerDayTimeBoundsTest {
         ////Execution
         checker.checkDayTimeBounds();
         
+        ////Expectation (on error)
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         if (start.compareTo(CHECKER_WORKDAY_LOWER_BOUND) < 0 || end.compareTo(CHECKER_WORKDAY_UPPER_BOUND) > 0) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
-            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage())));
+            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
         } else {
             assertEquals(CheckerReturn.VALID, checker.getResult());
             assertTrue(checker.getErrors().isEmpty());
         }
+    }
+    
+    @Test
+    public void testOutOfBoundsMultiple() {
+        ////Test values
+        TimeSpan start0 = CHECKER_WORKDAY_LOWER_BOUND.subtract(new TimeSpan(0, 1));
+        TimeSpan end0 = CHECKER_WORKDAY_UPPER_BOUND.subtract(new TimeSpan(1, 0));
+        TimeSpan pause0 = new TimeSpan(0, 0);
+        Entry entry0 = new Entry("Test", LocalDate.of(2019, 11, 20), start0, end0, pause0);
+        
+        TimeSpan start1 = CHECKER_WORKDAY_LOWER_BOUND.add(new TimeSpan(1, 0));
+        TimeSpan end1 = CHECKER_WORKDAY_UPPER_BOUND.add(new TimeSpan(0, 1));
+        TimeSpan pause1 = new TimeSpan(0, 0);
+        Entry entry1 = new Entry("Test", LocalDate.of(2019, 11, 22), start1, end1, pause1);
+        
+        Entry[] entries = {entry0, entry1};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Execution
+        checker.checkDayTimeBounds();
+        
+        ////Expectation (on error)
+        String error0 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry0.getDate());
+        String error1 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OUTOFBOUNDS.getErrorMessage(), entry1.getDate());
+        
+        ////Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error0)));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error1)));
     }
 }

--- a/src/test/java/checker/MiLoGCheckerDayTimeExceedancesTest.java
+++ b/src/test/java/checker/MiLoGCheckerDayTimeExceedancesTest.java
@@ -86,9 +86,12 @@ public class MiLoGCheckerDayTimeExceedancesTest {
         
         checker.checkDayTimeExceedances();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage(), entry1.getDate());
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -107,13 +110,16 @@ public class MiLoGCheckerDayTimeExceedancesTest {
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         MiLoGChecker checker = new MiLoGChecker(fullDoc);
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         for (TimeSpan[] pauseRule : PAUSE_RULES) {
             if (entry.getWorkingTime().compareTo(pauseRule[0]) >= 0) {
                 checker.checkDayTimeExceedances();
                 
                 assertEquals(CheckerReturn.INVALID, checker.getResult());
-                assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage())));
+                assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
                 return;
             }
         }
@@ -138,6 +144,9 @@ public class MiLoGCheckerDayTimeExceedancesTest {
         TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
         MiLoGChecker checker = new MiLoGChecker(fullDoc);
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage(), entry.getDate());
+        
         ////Assertions
         TimeSpan startToEnd = end.subtract(start);
         
@@ -147,7 +156,7 @@ public class MiLoGCheckerDayTimeExceedancesTest {
                     checker.checkDayTimeExceedances();
                     
                     assertEquals(CheckerReturn.INVALID, checker.getResult());
-                    assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage())));
+                    assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
                     return;
                 }
             }
@@ -155,5 +164,30 @@ public class MiLoGCheckerDayTimeExceedancesTest {
         
         assertEquals(CheckerReturn.VALID, checker.getResult());
         assertTrue(checker.getErrors().isEmpty());
+    }
+    
+    @Test
+    public void testMultipleExceedences() {
+        ////Test values
+        Entry entry1 = new Entry("Test1", LocalDate.of(2019, 11, 22), new TimeSpan(8, 0), new TimeSpan(12, 0), zeroTs);
+        Entry entry2 = new Entry("Test2", LocalDate.of(2019, 11, 22), new TimeSpan(16, 0), new TimeSpan(21, 0), zeroTs);
+        Entry entry3 = new Entry("Test3", LocalDate.of(2019, 11, 23), new TimeSpan(8, 0), new TimeSpan(20, 0), zeroTs);
+        
+        ////Checker initialization
+        Entry[] entries = {entry1, entry2, entry3};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Execution
+        checker.checkDayTimeExceedances();
+        
+        ////Expectation
+        String error1 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage(), entry1.getDate());
+        String error3 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_PAUSE.getErrorMessage(), entry3.getDate());
+        
+        ////Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error1)));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error3)));
     }
 }

--- a/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
+++ b/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
@@ -198,9 +198,12 @@ public class MiLoGCheckerTimeOverlapTest {
         ////Execution
         checker.checkTimeOverlap();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date0);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -233,9 +236,12 @@ public class MiLoGCheckerTimeOverlapTest {
         ////Execution
         checker.checkTimeOverlap();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date0);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -268,9 +274,12 @@ public class MiLoGCheckerTimeOverlapTest {
         ////Execution
         checker.checkTimeOverlap();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date0);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -303,9 +312,57 @@ public class MiLoGCheckerTimeOverlapTest {
         ////Execution
         checker.checkTimeOverlap();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date0);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
+    @Test
+    public void testMultipleEntriesWithMultipleOverlaps() {
+        ////Test values
+        TimeSpan start0 = new TimeSpan(8, 0);
+        TimeSpan end0 = new TimeSpan(14, 0);
+        TimeSpan pause0 = zeroTs;
+        LocalDate date0 = LocalDate.of(2019, 11, 22);
+        Entry entry0 = new Entry("Test 0", date0, start0, end0, pause0);
+        
+        TimeSpan start1 = new TimeSpan(11, 0);
+        TimeSpan end1 = new TimeSpan(13, 0);
+        TimeSpan pause1 = zeroTs;
+        LocalDate date1 = LocalDate.of(2019, 11, 22);
+        Entry entry1 = new Entry("Test 1", date1, start1, end1, pause1);
+        
+        TimeSpan start2 = new TimeSpan(8, 0);
+        TimeSpan end2 = new TimeSpan(12, 0);
+        TimeSpan pause2 = zeroTs;
+        LocalDate date2 = LocalDate.of(2019, 11, 25);
+        Entry entry2 = new Entry("Test 2", date2, start2, end2, pause2);
+        
+        TimeSpan start3 = new TimeSpan(11, 0);
+        TimeSpan end3 = new TimeSpan(14, 0);
+        TimeSpan pause3 = zeroTs;
+        LocalDate date3 = LocalDate.of(2019, 11, 25);
+        Entry entry3 = new Entry("Test 3", date3, start3, end3, pause3);
+        
+        Entry[] entries = {entry0, entry1, entry2, entry3};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, YEAR_MONTH, entries, zeroTs, zeroTs, zeroTs);
+        
+        ////Checker initialization
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Execution
+        checker.checkTimeOverlap();
+        
+        ////Expectation
+        String error0 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date0);
+        String error2 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_OVERLAP.getErrorMessage(), date2);
+        
+        ////Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error0)));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error2)));
+    }
 }

--- a/src/test/java/checker/MiLoGCheckerValidWorkingDaysTest.java
+++ b/src/test/java/checker/MiLoGCheckerValidWorkingDaysTest.java
@@ -88,9 +88,12 @@ public class MiLoGCheckerValidWorkingDaysTest {
         ////Executions
         checker.checkValidWorkingDays();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -111,9 +114,12 @@ public class MiLoGCheckerValidWorkingDaysTest {
         ////Executions
         checker.checkValidWorkingDays();
         
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -138,9 +144,12 @@ public class MiLoGCheckerValidWorkingDaysTest {
          * We assert Sunday instead of Holiday here because the possibility for a Sunday is much higher then for a holiday
          * and therefore this check is done beforehand.
          */
+        ////Expectation
+        String error = String.format(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage(), date);
+        
         ////Assertions
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error)));
     }
     
     @Test
@@ -172,17 +181,55 @@ public class MiLoGCheckerValidWorkingDaysTest {
         ////Executions
         checker.checkValidWorkingDays();
         
+        ////Expectation (on error)
+        String errorSunday = String.format(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage(), date);
+        String errorHoliday = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date);
+        
         ////Assertions
         if (randDate.getDayOfWeek() == DayOfWeek.SUNDAY) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
-            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_SUNDAY.getErrorMessage())));
+            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(errorSunday)));
         } else if (holidayChecker.isHoliday(randDate)) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
-            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage())));
+            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(errorHoliday)));
         } else {
             assertEquals(CheckerReturn.VALID, checker.getResult());
             assertTrue(checker.getErrors().isEmpty());
         }
+    }
+    
+    @Test
+    public void testMultipleInvalidWorkingDays() throws CheckerException {
+        ////Test values
+        TimeSpan start0 = new TimeSpan(0, 0);
+        TimeSpan end0 = new TimeSpan(0, 0);
+        TimeSpan pause0 = new TimeSpan(0, 0);
+        YearMonth yearMonth0 = YearMonth.of(2020, Month.JANUARY);
+        LocalDate date0 = LocalDate.of(yearMonth0.getYear(), yearMonth0.getMonthValue(), 1);
+        Entry entry0 = new Entry("Test", date0, start0, end0, pause0);
         
+        TimeSpan start1 = new TimeSpan(0, 0);
+        TimeSpan end1 = new TimeSpan(0, 0);
+        TimeSpan pause1 = new TimeSpan(0, 0);
+        YearMonth yearMonth1 = YearMonth.of(2020, Month.JANUARY);
+        LocalDate date1 = LocalDate.of(yearMonth1.getYear(), yearMonth1.getMonthValue(), 6);
+        Entry entry1 = new Entry("Test", date1, start1, end1, pause1);
+        
+        ////Checker initialization
+        Entry[] entries = {entry0, entry1};
+        TimeSheet fullDoc = new TimeSheet(EMPLOYEE, PROFESSION, yearMonth0, entries, zeroTs, zeroTs, zeroTs);
+        MiLoGChecker checker = new MiLoGChecker(fullDoc);
+        
+        ////Executions
+        checker.checkValidWorkingDays();
+        
+        ////Expectation
+        String error0 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date0);
+        String error1 = String.format(MiLoGChecker.CheckerErrorMessage.TIME_HOLIDAY.getErrorMessage(), date1);
+        
+        ////Assertions
+        assertEquals(CheckerReturn.INVALID, checker.getResult());
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error0)));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals(error1)));
     }
 }


### PR DESCRIPTION
- fix: add missing checkTimeOverlap call

- format specifiers in CheckerErrorMessage
- additional info when creating checker errors
- remove return on error (multiple errors possible)
- tests for multiple errors

resolves #45