### PR TITLE
Declare top level resource folder in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,9 @@
         </plugins>
         <resources>
             <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
                 <directory>src/main/resources/maven</directory>
                 <filtering>true</filtering>
             </resource>


### PR DESCRIPTION
- add src/main/resources to pom resources

when you start defining resources in the pom, you have to define all resources yourself