### PR TITLE
Use Strings for employee IDs to allow IDs with leading zeros

### DIFF
--- a/examples/schemas/global.json
+++ b/examples/schemas/global.json
@@ -12,7 +12,7 @@
 			"type": "string"
 		},
 		"staffId": {
-			"type": "integer"
+			"type": "string"
 		},
 		"department": {
 			"type": "string"

--- a/src/main/java/data/Employee.java
+++ b/src/main/java/data/Employee.java
@@ -6,14 +6,14 @@ package data;
 public class Employee {
 
     private final String name;
-    private final int id;
+    private final String id;
     
     /**
      * Constructs a new employee instance.
      * @param name - The full name of the employee
      * @param id - The employee id
      */
-    public Employee(String name, int id) {
+    public Employee(String name, String id) {
         this.name = name;
         this.id = id;
     }
@@ -30,7 +30,7 @@ public class Employee {
      * Gets the id of an employee.
      * @return The id of the employee.
      */
-    public int getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -43,11 +43,8 @@ public class Employee {
         Employee otherEmployee = (Employee)other;
         if (!this.name.equals(otherEmployee.name)) {
             return false;
-        } else if (this.id != otherEmployee.id) {
-            return false;
-        } else {
-            return true;
-        }
+        } else
+            return this.id.equals(otherEmployee.id);
     }
 
 }

--- a/src/main/java/io/LatexGenerator.java
+++ b/src/main/java/io/LatexGenerator.java
@@ -113,7 +113,7 @@ public class LatexGenerator implements IGenerator {
                 value = escapeText(timeSheet.getEmployee().getName());
                 break;
             case EMPLOYEE_ID:
-                value = Integer.toString(timeSheet.getEmployee().getId());
+                value = timeSheet.getEmployee().getId();
                 break;
             case GFUB:
                 if (timeSheet.getProfession().getWorkingArea() == WorkingArea.GF) {

--- a/src/main/java/parser/json/GlobalJson.java
+++ b/src/main/java/parser/json/GlobalJson.java
@@ -11,7 +11,7 @@ import data.WorkingArea;
 class GlobalJson {
 
     private final String name;
-    private final int staffId;
+    private final String staffId;
     private final String department;
     private final TimeSpan workingTime;
     private final double wage;
@@ -20,7 +20,7 @@ class GlobalJson {
     @JsonCreator
     GlobalJson(
         @JsonProperty(value="name", required=true) String name,
-        @JsonProperty(value="staffId", required=true) int staffId,
+        @JsonProperty(value="staffId", required=true) String staffId,
         @JsonProperty(value="department", required=true) String department,
         @JsonProperty(value="workingTime", required=true) String workingTime,
         @JsonProperty(value="wage", required=true) double wage,
@@ -38,7 +38,7 @@ class GlobalJson {
         return name;
     }
 
-    public int getStaffId() {
+    public String getStaffId() {
         return staffId;
     }
 

--- a/src/test/java/checker/MiLoGCheckerCheckTest.java
+++ b/src/test/java/checker/MiLoGCheckerCheckTest.java
@@ -18,7 +18,7 @@ import data.WorkingArea;
 public class MiLoGCheckerCheckTest {
 
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerDayPauseTimeTest.java
+++ b/src/test/java/checker/MiLoGCheckerDayPauseTimeTest.java
@@ -26,7 +26,7 @@ public class MiLoGCheckerDayPauseTimeTest {
     private static final int RANDOM_MINUTES_BOUND = 60;
     
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerDayTimeBoundsTest.java
+++ b/src/test/java/checker/MiLoGCheckerDayTimeBoundsTest.java
@@ -27,7 +27,7 @@ public class MiLoGCheckerDayTimeBoundsTest {
     private static final int RANDOM_MINUTES_BOUND = 60;
     
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerDayTimeExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerDayTimeExceedanceTest.java
@@ -24,7 +24,7 @@ public class MiLoGCheckerDayTimeExceedanceTest {
     private static final int RANDOM_MINUTES_BOUND = 60;
     
     //// Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan ZERO_TS = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerDepartmentNameTest.java
+++ b/src/test/java/checker/MiLoGCheckerDepartmentNameTest.java
@@ -21,7 +21,7 @@ public class MiLoGCheckerDepartmentNameTest {
             new TimeSpan(0, 0), new TimeSpan(0, 0), new TimeSpan(0, 0), false)};
     
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);
     

--- a/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
@@ -23,7 +23,7 @@ public class MiLoGCheckerRowNumExceedanceTest {
     private static final int CHECKER_ENTRY_MAX = MiLoGChecker.getMaxEntries();
     
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
+++ b/src/test/java/checker/MiLoGCheckerTimeOverlapTest.java
@@ -18,7 +18,7 @@ import data.WorkingArea;
 public class MiLoGCheckerTimeOverlapTest {
 
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerTotalTimeExceedanceTest.java
@@ -24,7 +24,7 @@ public class MiLoGCheckerTotalTimeExceedanceTest {
     private static final int RANDOM_MINUTES_BOUND = 60;
     
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);
     

--- a/src/test/java/checker/MiLoGCheckerValidWorkingDaysTest.java
+++ b/src/test/java/checker/MiLoGCheckerValidWorkingDaysTest.java
@@ -31,7 +31,7 @@ import data.WorkingArea;
 public class MiLoGCheckerValidWorkingDaysTest {
 
     ////Placeholder for time sheet construction
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);
     

--- a/src/test/java/data/TimeSheetArithmeticTest.java
+++ b/src/test/java/data/TimeSheetArithmeticTest.java
@@ -12,7 +12,7 @@ public class TimeSheetArithmeticTest {
 
     @Test
     public void testGetTotalWorkTime() {
-        Employee employee = new Employee("Moritz Gstür", 1234567);
+        Employee employee = new Employee("Moritz Gstür", "1234567");
         Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
         TimeSpan zeroTs = new TimeSpan(0, 0);
         Entry[] entries = new Entry[7];
@@ -30,7 +30,7 @@ public class TimeSheetArithmeticTest {
     
     @Test
     public void testGetTotalVacationTime() {
-        Employee employee = new Employee("Moritz Gstür", 1234567);
+        Employee employee = new Employee("Moritz Gstür", "1234567");
         Profession profession = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
         TimeSpan zeroTs = new TimeSpan(0, 0);
         Entry[] entries = new Entry[4];

--- a/src/test/java/data/TimeSheetCommonTest.java
+++ b/src/test/java/data/TimeSheetCommonTest.java
@@ -18,7 +18,7 @@ public class TimeSheetCommonTest {
         TimeSpan succTransfer = new TimeSpan(20, 0);
         
         ////TimeSheet initialization
-        Employee employee = new Employee("Max Mustermann", 1234567);
+        Employee employee = new Employee("Max Mustermann", "1234567");
         Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
         YearMonth yearMonth = YearMonth.of(2019, 11);
         Entry[] entries = new Entry[] {
@@ -37,7 +37,7 @@ public class TimeSheetCommonTest {
         TimeSpan succTransfer = new TimeSpan(20, 0);
         
         ////TimeSheet initialization
-        Employee employee = new Employee("Max Mustermann", 1234567);
+        Employee employee = new Employee("Max Mustermann", "1234567");
         Profession profession = new Profession("IPD", WorkingArea.UB, maxWorkingTime, 10.31);
         YearMonth yearMonth = YearMonth.of(2019, 11);
         Entry[] entries = new Entry[] {

--- a/src/test/java/io/LatexGeneratorEscapeTest.java
+++ b/src/test/java/io/LatexGeneratorEscapeTest.java
@@ -51,7 +51,7 @@ public class LatexGeneratorEscapeTest {
     @Test
     public void testEscapeTimesheetWithoutSpecialCharacters() {
         // data
-        Employee employee = new Employee("Max Mustermann", 1234567);
+        Employee employee = new Employee("Max Mustermann", "1234567");
         Profession profession = new Profession("Institut für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 23.71);
         Entry[] entries = new Entry[] {
             new Entry("Fragen und Antworten", LocalDate.of(2020, 3, 21), new TimeSpan(9, 0), new TimeSpan(12, 0), new TimeSpan(0, 30), false)
@@ -74,7 +74,7 @@ public class LatexGeneratorEscapeTest {
     @Test
     public void testEscapeTimesheetWithSpecialCharacters() {
         // data
-        Employee employee = new Employee("Max #Mustermann", 1234567);
+        Employee employee = new Employee("Max #Mustermann", "1234567");
         Profession profession = new Profession("Institut f~r Informatik", WorkingArea.UB, new TimeSpan(40, 0), 23.71);
         Entry[] entries = new Entry[] {
             new Entry("Fragen & Antworten", LocalDate.of(2020, 3, 21), new TimeSpan(9, 0), new TimeSpan(12, 0), new TimeSpan(0, 30), false)

--- a/src/test/java/io/LatexGeneratorPlaceholderTest.java
+++ b/src/test/java/io/LatexGeneratorPlaceholderTest.java
@@ -26,7 +26,7 @@ public class LatexGeneratorPlaceholderTest {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yy");
 
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
 

--- a/src/test/java/io/LatexGeneratorTest.java
+++ b/src/test/java/io/LatexGeneratorTest.java
@@ -22,7 +22,7 @@ public class LatexGeneratorTest {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yy");
 
-    private static final Employee EMPLOYEE = new Employee("Max Mustermann", 1234567);
+    private static final Employee EMPLOYEE = new Employee("Max Mustermann", "1234567");
     private static final Profession PROFESSION = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
     private static final YearMonth YEAR_MONTH = YearMonth.of(2019, Month.NOVEMBER);
     private static final TimeSpan zeroTs = new TimeSpan(0, 0);

--- a/src/test/java/parser/ParserJsonTest.java
+++ b/src/test/java/parser/ParserJsonTest.java
@@ -58,7 +58,7 @@ public class ParserJsonTest {
     @Test
     public void testParseTimeSheetJson() throws ParseException {
         // data
-        Employee expectedEmployee = new Employee("Max Mustermann", 1234567);
+        Employee expectedEmployee = new Employee("Max Mustermann", "1234567");
         Profession expectedProfession = new Profession("Fakultät für Informatik", WorkingArea.UB, new TimeSpan(40, 0), 10.31);
         Entry[] expectedEntries = new Entry[] {
             new Entry("Korrektur", LocalDate.of(2019, 11, 2), new TimeSpan(10, 0), new TimeSpan(11, 0), new TimeSpan(0, 0), false),

--- a/src/test/java/parser/json/JsonGlobalParserTest.java
+++ b/src/test/java/parser/json/JsonGlobalParserTest.java
@@ -1,13 +1,13 @@
 package parser.json;
 
-import static org.junit.Assert.*;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import data.Employee;
 import data.Profession;
 import data.TimeSpan;
 import data.WorkingArea;
+import org.junit.Test;
 import parser.IGlobalParser;
 import parser.ParseException;
 
@@ -98,7 +98,28 @@ public class JsonGlobalParserTest {
         Employee employee = parser.getEmployee();
 
         // assert
-        assertEquals(new Employee("Max Mustermann", 1234567), employee);
+        assertEquals(new Employee("Max Mustermann", "1234567"), employee);
+    }
+
+    @Test
+    public void testParseEmployeeLeadingZeroId() throws ParseException {
+        // data
+        IGlobalParser parser = new JsonGlobalParser(
+          "{" +
+            "\"name\": \"Max Mustermann\"," +
+            "\"staffId\": \"01234567\"," +
+            "\"department\": \"Fakultät für Informatik\"," +
+            "\"workingTime\": \"40:00\"," +
+            "\"wage\": 10.31," +
+            "\"workingArea\": \"ub\"" +
+            "}"
+        );
+
+        // execute
+        Employee employee = parser.getEmployee();
+
+        // assert
+        assertEquals(new Employee("Max Mustermann", "01234567"), employee);
     }
 
     @Test(expected = ParseException.class)


### PR DESCRIPTION
## About
This PR changes the employee id field to a String, allowing leading zeros.

## Problems
It might not be backwards compatible with existing global JSONs.