### PR TITLE
Fix the wrong number of max rows in MiLoGChecker 

### DIFF
--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -31,7 +31,7 @@ public class MiLoGChecker implements IChecker {
     
     //TODO Replace with enum
     private static final TimeSpan[][] PAUSE_RULES = {{new TimeSpan(6, 0), new TimeSpan(0, 30)},{new TimeSpan(9, 0), new TimeSpan(0, 45)}};
-    private static final int MAX_ROW_NUM = 22;
+    private static final int MAX_ROW_NUM = 20;
     private static final GermanState STATE = GermanState.BW;
 
     private final TimeSheet timeSheet;

--- a/src/main/resources/MiLoG_Template.tex
+++ b/src/main/resources/MiLoG_Template.tex
@@ -28,7 +28,7 @@
 	\begin{center}
 		\begin{tabular}{| P{6.7cm} | P{2cm} | P{1.8cm} | P{1.8cm} | P{1.8cm} | P{2.4cm} |}
 			\hline
-			%Line 1
+			%Table Header 1
 			\textbf{T\"atigkeit (Stichwort, Projekt)}
 			& \textbf{Datum}
 			& \textbf{Beginn}
@@ -36,7 +36,7 @@
 			& \textbf{Pause}
 			& \textbf{Arbeitszeit\textsuperscript{1}}\\
 			\hline
-			%Line 2
+			%Table Header 2
 			%empty
 			& \textbf{(tt.mm.jj)}
 			& \textbf{(hh:mm)}
@@ -44,7 +44,7 @@
 			& \textbf{(hh:mm)}
 			& \textbf{(hh:mm)}\\
 			\hline
-			%Line 3
+			%Row 1
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -52,7 +52,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 4
+			%Row 2
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -60,7 +60,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 5
+			%Row 3
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -68,7 +68,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 6
+			%Row 4
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -76,7 +76,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 7
+			%Row 5
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -84,7 +84,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 8
+			%Row 6
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -92,7 +92,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 9
+			%Row 7
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -100,7 +100,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 10
+			%Row 8
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -108,7 +108,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 11
+			%Row 9
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -116,7 +116,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 12
+			%Row 10
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -124,7 +124,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 13
+			%Row 11
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -132,7 +132,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 14
+			%Row 12
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -140,7 +140,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 15
+			%Row 13
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -148,7 +148,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 16
+			%Row 14
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -156,7 +156,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 17
+			%Row 15
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -164,7 +164,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 18
+			%Row 16
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -172,7 +172,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 19
+			%Row 17
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -180,7 +180,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 20
+			%Row 18
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -188,7 +188,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 21
+			%Row 19
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}
@@ -196,7 +196,7 @@
 			& \mbox{!break}
 			& \mbox{!dayTotal}\\
 			\hline
-			%Line 22
+			%Row 20
 			\mbox{!action}
 			& \mbox{!date}
 			& \mbox{!begin}


### PR DESCRIPTION
Fixed #115 

The MAX_ROW_NUM value was falsely set to 22. The actual number of usable rows in the MiLoG_Template.tex file is 20. The first two table rows are used as a header.

This resulted in up to two rows being lost silently during the latex generation.

I also tried to improve the comments in the MiLoG_Template to reflect the actual number of usable rows. 