### PR TITLE
Fix holiday check for school holidays

### DIFF
--- a/src/main/java/parser/json/JsonHolidayParser.java
+++ b/src/main/java/parser/json/JsonHolidayParser.java
@@ -19,6 +19,11 @@ import parser.ParseException;
  * elements specified by {@link IHolidayParser} from a json string.
  */
 public class JsonHolidayParser implements IHolidayParser {
+
+    private static final String SCHOOL_HOLIDAY_NOTE = "Gemäß § 4 Abs. 3 des Feiertagsgesetzes von " +
+            "Baden-Württemberg[10] haben Schüler am Gründonnerstag und am Reformationstag schulfrei. In der Regel " +
+            "legt das Kultusministerium die Ferientermine so fest, dass diese beiden Tage in die Osterferien bzw. " +
+            "in die Herbstferien fallen.";
     
     private final String json;
     
@@ -50,10 +55,12 @@ public class JsonHolidayParser implements IHolidayParser {
         try {
             HolidayMapJson holidayMap = parseJson();
             
-            return holidayMap.getHolidays().entrySet().stream().map(e -> new Holiday(
-                e.getValue().getDate(),
-                e.getKey()
-            )).collect(Collectors.toList());
+            return holidayMap.getHolidays().entrySet().stream()
+                    .filter(e -> e.getValue().getNote() == null || !e.getValue().getNote().equals(SCHOOL_HOLIDAY_NOTE))
+                    .map(e -> new Holiday(
+                            e.getValue().getDate(),
+                            e.getKey()
+                    )).collect(Collectors.toList());
         } catch (JsonProcessingException e) {
             throw new ParseException(e.getMessage());
         }

--- a/src/main/java/parser/json/JsonHolidayParser.java
+++ b/src/main/java/parser/json/JsonHolidayParser.java
@@ -20,10 +20,7 @@ import parser.ParseException;
  */
 public class JsonHolidayParser implements IHolidayParser {
 
-    private static final String SCHOOL_HOLIDAY_NOTE = "Gemäß § 4 Abs. 3 des Feiertagsgesetzes von " +
-            "Baden-Württemberg[10] haben Schüler am Gründonnerstag und am Reformationstag schulfrei. In der Regel " +
-            "legt das Kultusministerium die Ferientermine so fest, dass diese beiden Tage in die Osterferien bzw. " +
-            "in die Herbstferien fallen.";
+    private static final String SCHOOL_HOLIDAY_NOTE = "schulfrei";
     
     private final String json;
     
@@ -56,7 +53,8 @@ public class JsonHolidayParser implements IHolidayParser {
             HolidayMapJson holidayMap = parseJson();
             
             return holidayMap.getHolidays().entrySet().stream()
-                    .filter(e -> e.getValue().getNote() == null || !e.getValue().getNote().equals(SCHOOL_HOLIDAY_NOTE))
+                    .filter(e -> e.getValue().getNote() == null ||
+                            !e.getValue().getNote().contains(SCHOOL_HOLIDAY_NOTE))
                     .map(e -> new Holiday(
                             e.getValue().getDate(),
                             e.getKey()


### PR DESCRIPTION
Currently the API feiertag-api.de is used and all entries are interpreted as work holidays. Currently two days are only school holidays and not work holidays. These dates has a special note attached in JSON. This pull request checks for this note and ignores the day.

It is not really future proof because this check fails, when the note is changed, but I don't know any better way.