### PR TITLE
Improve too many entries error message

### DIFF
--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -250,8 +250,9 @@ public class MiLoGChecker implements IChecker {
      * Checks whether the number of entries exceeds the maximum number of rows of the template document.
      */
     protected void checkRowNumExceedance() {
-        if (timeSheet.getEntries().size() > MAX_ROW_NUM) {
-            errors.add(new CheckerError(MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE));
+        int rowCount = timeSheet.getEntries().size();
+        if (rowCount > MAX_ROW_NUM) {
+            errors.add(new CheckerError(MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE, MAX_ROW_NUM, rowCount - MAX_ROW_NUM));
             result = CheckerReturn.INVALID;
         }
     }

--- a/src/main/resources/i18n/MessageBundle.properties
+++ b/src/main/resources/i18n/MessageBundle.properties
@@ -29,7 +29,7 @@ error.checker.timeSunday = The {0,date} is a sunday, which is not a valid workin
 error.checker.timeHoliday = The {0,date} is an official holiday, which is not a valid working day.
 error.checker.timePause = Maximum working time without pause exceeded on {0,date}.
 error.checker.timeOverlap = Start/End times in the time sheet overlap on {0,date}.
-error.checker.rowNumExceedance = Exceeded the maximum number of rows for the document.
+error.checker.rowNumExceedance = Exceeded the maximum number of rows ({0}) by {1} rows.
 error.checker.nameMissing = Name of the departement is missing.
 
 error.entry.timeOverUpperLimit = Start and end time may not be greater than 23:59.

--- a/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
+++ b/src/test/java/checker/MiLoGCheckerRowNumExceedanceTest.java
@@ -100,9 +100,9 @@ public class MiLoGCheckerRowNumExceedanceTest {
         ////Assertions
         assertTrue(numberOfEntries == timeSheet.getEntries().size());
         assertEquals(CheckerReturn.INVALID, checker.getResult());
-        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals( MiLoGChecker.MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE.getErrorMessage())));
+        assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals( MiLoGChecker.MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE.getErrorMessage(CHECKER_ENTRY_MAX, numberOfEntries - CHECKER_ENTRY_MAX))));
     }
-    
+
     @Test
     public void testExceedanceRandom() {
         ////Random
@@ -133,7 +133,7 @@ public class MiLoGCheckerRowNumExceedanceTest {
         assertTrue(numberOfEntries == timeSheet.getEntries().size());
         if (timeSheet.getEntries().size() > MiLoGChecker.getMaxEntries()) {
             assertEquals(CheckerReturn.INVALID, checker.getResult());
-            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals( MiLoGChecker.MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE.getErrorMessage())));
+            assertTrue(checker.getErrors().stream().anyMatch(item -> item.getErrorMessage().equals( MiLoGChecker.MiLoGCheckerErrorMessageProvider.ROWNUM_EXCEEDENCE.getErrorMessage(CHECKER_ENTRY_MAX, numberOfEntries - CHECKER_ENTRY_MAX))));
         } else {
             assertEquals(CheckerReturn.VALID, checker.getResult());
             assertTrue(checker.getErrors().isEmpty());


### PR DESCRIPTION
If the number of entries exceeds the available number of rows in the template the following error message is shown:

> Exceeded the maximum number of rows for the document.

This message lacks helpful information needed to fix the error (e.g. how many entries have to be removed). Therefore I propose the following error message as a replacement:

> Exceeded the maximum number of rows ({MAX_ROW_NUM}) by {rowCount - MAX_ROW_NUM} rows.

Signed-off-by: Moritz Hertler <mo.hertler@gmail.com>