### PR TITLE
Template PDF Bugfix and No Holiday Entries

### DIFF
--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -316,7 +316,14 @@ public class UserInterface {
 	}
 
 	public boolean isSpaceForNewEntry() {
-		return listModel.size() < MAX_ENTRIES;
+		// Loop and exclude holiday entries. Keeping track live invite bugs, and for <= 22 entries
+		// + reasonable holidays, this works. If you really want to just break the program, there
+		// are easier ways of doing it
+		int entries = listModel.size();
+		for (int i = 0; i < itemList.getModel().getSize(); i++) {
+			if (listModel.getElementAt(i).isVacation()) entries--;
+		}
+		return entries < MAX_ENTRIES;
 	}
 
 	public void addEntry(TimesheetEntry entry) {

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -316,12 +316,13 @@ public class UserInterface {
 	}
 
 	public boolean isSpaceForNewEntry() {
-		// Loop and exclude holiday entries. Keeping track live invite bugs, and for <= 22 entries
-		// + reasonable holidays, this works. If you really want to just break the program, there
-		// are easier ways of doing it
+		// Loop and exclude holiday entries. Keeping track live invite bugs, and for <=
+		// 22 entries + reasonable holidays, this works. If you really want to just
+		// break the program, there are easier ways of doing it
 		int entries = listModel.size();
 		for (int i = 0; i < itemList.getModel().getSize(); i++) {
-			if (listModel.getElementAt(i).isVacation()) entries--;
+			if (listModel.getElementAt(i).isVacation())
+				entries--;
 		}
 		return entries < MAX_ENTRIES;
 	}

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -20,7 +20,8 @@ import java.util.logging.Logger;
 
 public class PDFCompiler {
 
-	private static final Object LOADER = new Object(){};
+	private static final Object LOADER = new Object() {
+	};
 
 	private PDFCompiler() {
 		throw new IllegalAccessError();
@@ -69,8 +70,9 @@ public class PDFCompiler {
 		form.getField("monatliche SollArbeitszeit").setValue(global.getWorkingTime()); // Again hours probably
 
 		try {
-			form.getField("Ich bestätige die Richtigkeit der Angaben").setValue("%s, %s".formatted(
-					DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDateTime.now()), JSONHandler.getUISettings().getAddSignature() ? global.getName() : ""));
+			form.getField("Ich bestätige die Richtigkeit der Angaben")
+					.setValue("%s, %s".formatted(DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDateTime.now()),
+							JSONHandler.getUISettings().getAddSignature() ? global.getName() : ""));
 		} catch (EOFException ignored) {
 			Logger.getGlobal().warning("Could not load font for signature field when exporting to PDF. Proceeding with default.");
 		}
@@ -90,7 +92,8 @@ public class PDFCompiler {
 			}
 
 			form.getField("Tätigkeit Stichwort ProjektRow%d".formatted(fieldIndex)).setValue(entry.getAction());
-			form.getField("ttmmjjRow%d".formatted(fieldIndex)).setValue(dayFormatter.format(LocalDateTime.of(month.getYear(), month.getMonth(), entry.getDay(), 0, 0)));
+			form.getField("ttmmjjRow%d".formatted(fieldIndex))
+					.setValue(dayFormatter.format(LocalDateTime.of(month.getYear(), month.getMonth(), entry.getDay(), 0, 0)));
 			form.getField("hhmmRow%d".formatted(fieldIndex)).setValue(entry.getStart());
 			form.getField("hhmmRow%d_2".formatted(fieldIndex)).setValue(entry.getEnd());
 			form.getField("hhmmRow%d_3".formatted(fieldIndex)).setValue(entry.getPause());

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -20,13 +20,14 @@ import java.util.logging.Logger;
 
 public class PDFCompiler {
 
+	private static final Object LOADER = new Object(){};
+
 	private PDFCompiler() {
 		throw new IllegalAccessError();
 	}
 
 	public static Optional<String> compileToPDF(Global global, Month month, File targetFile) {
-		// Object.class.getResourceAsStream cannot find the pdf, at least not on Win11
-		try (InputStream templateStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("pdf/template.pdf")) {
+		try (InputStream templateStream = LOADER.getClass().getResourceAsStream("/pdf/template.pdf")) {
 			if (templateStream == null) {
 				return Optional.of("Template PDF not found in resources.");
 			}
@@ -76,7 +77,7 @@ public class PDFCompiler {
 
 		final DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("dd.MM.yy");
 
-		for (int i = 0, m = 1; i < month.getEntries().size(); i++) {
+		for (int i = 0, fieldIndex = 1; i < month.getEntries().size(); i++) {
 			Month.Entry entry = month.getEntries().get(i);
 			Time time = Time.parseTime(entry.getEnd());
 			time.subtractTime(Time.parseTime(entry.getStart()));
@@ -88,15 +89,15 @@ public class PDFCompiler {
 				continue;
 			}
 
-			form.getField("Tätigkeit Stichwort ProjektRow%d".formatted(m)).setValue(entry.getAction());
-			form.getField("ttmmjjRow%d".formatted(m)).setValue(dayFormatter.format(LocalDateTime.of(month.getYear(), month.getMonth(), entry.getDay(), 0, 0)));
-			form.getField("hhmmRow%d".formatted(m)).setValue(entry.getStart());
-			form.getField("hhmmRow%d_2".formatted(m)).setValue(entry.getEnd());
-			form.getField("hhmmRow%d_3".formatted(m)).setValue(entry.getPause());
+			form.getField("Tätigkeit Stichwort ProjektRow%d".formatted(fieldIndex)).setValue(entry.getAction());
+			form.getField("ttmmjjRow%d".formatted(fieldIndex)).setValue(dayFormatter.format(LocalDateTime.of(month.getYear(), month.getMonth(), entry.getDay(), 0, 0)));
+			form.getField("hhmmRow%d".formatted(fieldIndex)).setValue(entry.getStart());
+			form.getField("hhmmRow%d_2".formatted(fieldIndex)).setValue(entry.getEnd());
+			form.getField("hhmmRow%d_3".formatted(fieldIndex)).setValue(entry.getPause());
 
 			String timeFieldValue = time.toString();
-			form.getField("hhmmRow%d_4".formatted(m)).setValue(timeFieldValue);
-			m++;
+			form.getField("hhmmRow%d_4".formatted(fieldIndex)).setValue(timeFieldValue);
+			fieldIndex++;
 		}
 
 		form.getField("Summe").setValue(timeSum.toString()); // Total time worked

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -20,15 +20,12 @@ import java.util.logging.Logger;
 
 public class PDFCompiler {
 
-	private static final Object LOADER = new Object() {
-	};
-
 	private PDFCompiler() {
 		throw new IllegalAccessError();
 	}
 
 	public static Optional<String> compileToPDF(Global global, Month month, File targetFile) {
-		try (InputStream templateStream = LOADER.getClass().getResourceAsStream("/pdf/template.pdf")) {
+		try (InputStream templateStream = PDFCompiler.class.getResourceAsStream("/pdf/template.pdf")) {
 			if (templateStream == null) {
 				return Optional.of("Template PDF not found in resources.");
 			}
@@ -79,7 +76,8 @@ public class PDFCompiler {
 
 		final DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("dd.MM.yy");
 
-		for (int i = 0, fieldIndex = 1; i < month.getEntries().size(); i++) {
+		int fieldIndex = 1;
+		for (int i = 0; i < month.getEntries().size(); i++) {
 			Month.Entry entry = month.getEntries().get(i);
 			Time time = Time.parseTime(entry.getEnd());
 			time.subtractTime(Time.parseTime(entry.getStart()));

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -81,6 +81,7 @@ public class PDFCompiler {
 			Time time = Time.parseTime(entry.getEnd());
 			time.subtractTime(Time.parseTime(entry.getStart()));
 			time.subtractTime(Time.parseTime(entry.getPause()));
+			timeSum.addTime(time);
 
 			if (entry.isVacation()) {
 				timeVacation.addTime(time);
@@ -95,7 +96,6 @@ public class PDFCompiler {
 
 			String timeFieldValue = time.toString();
 			form.getField("hhmmRow%d_4".formatted(m)).setValue(timeFieldValue);
-			timeSum.addTime(time);
 			m++;
 		}
 


### PR DESCRIPTION
Fixed a bug where the template PDF could not be found despite being there. The code is marginally different and has been tested on MacOS Sequoia 16 and Windows 11.

Additionally, Holiday Entries do not get entries in the table on the exported PDF Sheet. They also do not count towards the 22 Entry limit anymore, of course. There are plans to make entering holiday time more convenient, but this will do for now.
This also adds error handling for fonts for the signature text field, since that occurred as well. Nothing bad happens, it just can't find the font it wants.

This does not affect generated Tex Files.