### PR TITLE
Bugfixes for opening new Files and worked time

### DIFF
--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -495,9 +495,10 @@ public final class DialogHelper {
 		if (!isVacation.isSelected()) {
 			long totalMinutes = workDuration.toMinutes();
 			long breakMinutes = breakTime.getHour() * 60L + breakTime.getMinute();
-			if (totalMinutes >= 540 && breakMinutes < 60) {
+			// FROM: https://www.gesetze-im-internet.de/arbzg/__4.html#:~:text=Arbeitszeitgesetz%20(ArbZG),neun%20Stunden%20insgesamt%20zu%20unterbrechen.
+			if (totalMinutes > 540 && breakMinutes < 45) {
 				durationWarningLabel.setText("Break must be at least 1 hour for work of 9 hours or more");
-			} else if (totalMinutes >= 360 && breakMinutes < 30) {
+			} else if (totalMinutes > 360 && breakMinutes < 30) {
 				durationWarningLabel.setText("Break must be at least 30 minutes for work over 6 hours");
 			} else {
 				durationWarningLabel.setText(" ");

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -30,6 +30,8 @@ public final class DialogHelper {
 	static final Pattern TIME_PATTERN_SEMI_SMALL = Pattern.compile("^(\\d{1,2}):(\\d)$");
 
 	private static final int MAX_TEXT_LENGTH_ACTIVITY = 27;
+	private static final int MIN_BREAK_SIX_HOURS = 30;
+	private static final int MIN_BREAK_NINE_HOURS = 45;
 
 	private static final String ACTIVITY_MESSAGE = "You need to enter an activity!";
 
@@ -498,10 +500,10 @@ public final class DialogHelper {
 			long breakMinutes = breakTime.getHour() * 60L + breakTime.getMinute();
 			// FROM:
 			// https://www.gesetze-im-internet.de/arbzg/__4.html#:~:text=Arbeitszeitgesetz%20(ArbZG),neun%20Stunden%20insgesamt%20zu%20unterbrechen.
-			if (totalMinutes > 540 && breakMinutes < 45) {
-				durationWarningLabel.setText("Break must be at least 1 hour for work of 9 hours or more");
-			} else if (totalMinutes > 360 && breakMinutes < 30) {
-				durationWarningLabel.setText("Break must be at least 30 minutes for work over 6 hours");
+			if (totalMinutes > 540 && breakMinutes < MIN_BREAK_NINE_HOURS) {
+				durationWarningLabel.setText("Break must be at least %d minutes for work of 9 hours or more".formatted(MIN_BREAK_NINE_HOURS));
+			} else if (totalMinutes > 360 && breakMinutes < MIN_BREAK_SIX_HOURS) {
+				durationWarningLabel.setText("Break must be at least %d minutes for work over 6 hours".formatted(MIN_BREAK_SIX_HOURS));
 			} else {
 				durationWarningLabel.setText(" ");
 			}

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -263,13 +263,14 @@ public final class DialogHelper {
 
 	/**
 	 * The Action for the "Make Entry" Button in the "Add/Edit Entry" Dialog.
-	 * Returns if the dialog should be disposed (success) or if it should be
-	 * kept open (failure).
-	 * @param parentUI The parent UserInterface.
+	 * Returns if the dialog should be disposed (success) or if it should be kept
+	 * open (failure).
+	 * 
+	 * @param parentUI             The parent UserInterface.
 	 * @param durationWarningLabel The warning label for the work time message.
-	 * @param actionTextArea The text area for the activity.
-	 * @param timeFields The array of fields for the times.
-	 * @param vacationCheckBox The vacation checkbox.
+	 * @param actionTextArea       The text area for the activity.
+	 * @param timeFields           The array of fields for the times.
+	 * @param vacationCheckBox     The vacation checkbox.
 	 * @return True if the dialog should be disposed, false if not.
 	 */
 	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextArea actionTextArea, JTextField[] timeFields,
@@ -495,7 +496,8 @@ public final class DialogHelper {
 		if (!isVacation.isSelected()) {
 			long totalMinutes = workDuration.toMinutes();
 			long breakMinutes = breakTime.getHour() * 60L + breakTime.getMinute();
-			// FROM: https://www.gesetze-im-internet.de/arbzg/__4.html#:~:text=Arbeitszeitgesetz%20(ArbZG),neun%20Stunden%20insgesamt%20zu%20unterbrechen.
+			// FROM:
+			// https://www.gesetze-im-internet.de/arbzg/__4.html#:~:text=Arbeitszeitgesetz%20(ArbZG),neun%20Stunden%20insgesamt%20zu%20unterbrechen.
 			if (totalMinutes > 540 && breakMinutes < 45) {
 				durationWarningLabel.setText("Break must be at least 1 hour for work of 9 hours or more");
 			} else if (totalMinutes > 360 && breakMinutes < 30) {

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -217,8 +217,8 @@ public final class DialogHelper {
 
 		// Action listeners for buttons
 		makeEntryButton.addActionListener(e -> {
-			makeEntryAction(parentUi, durationWarningLabel, actionTextArea, timeFields, vacationCheckBox);
-			dialog.dispose();
+			if (makeEntryAction(parentUi, durationWarningLabel, actionTextArea, timeFields, vacationCheckBox))
+				dialog.dispose();
 		});
 
 		cancelButton.addActionListener(e -> {
@@ -261,7 +261,18 @@ public final class DialogHelper {
 		dialog.setVisible(true);
 	}
 
-	private static void makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextArea actionTextArea, JTextField[] timeFields,
+	/**
+	 * The Action for the "Make Entry" Button in the "Add/Edit Entry" Dialog.
+	 * Returns if the dialog should be disposed (success) or if it should be
+	 * kept open (failure).
+	 * @param parentUI The parent UserInterface.
+	 * @param durationWarningLabel The warning label for the work time message.
+	 * @param actionTextArea The text area for the activity.
+	 * @param timeFields The array of fields for the times.
+	 * @param vacationCheckBox The vacation checkbox.
+	 * @return True if the dialog should be disposed, false if not.
+	 */
+	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextArea actionTextArea, JTextField[] timeFields,
 			JCheckBox vacationCheckBox) {
 		if (durationWarningLabel.getText().isBlank()) {
 			if (actionTextArea.getText().isBlank()) {
@@ -293,7 +304,7 @@ public final class DialogHelper {
 			timer.setRepeats(false); // Only execute once
 			timer.start();
 
-			return;
+			return false;
 		}
 
 		// No break
@@ -306,6 +317,7 @@ public final class DialogHelper {
 				vacationCheckBox.isSelected());
 		parentUI.addEntry(newEntry);
 		parentUI.setHasUnsavedChanges(true);
+		return true;
 	}
 
 	private static void updateTimeFieldView(int index, int breakFieldIndex, JTextField[] timeFields, JLabel[] errorLabels, JLabel durationSummaryValue,

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -265,7 +265,7 @@ public class UserInterface {
 	public void openFile(File openFile) {
 		if (openFile == null)
 			return;
-		if (!clearWorkspace())	// Don't proceed: Clearing was cancelled
+		if (!clearWorkspace()) // Don't proceed: Clearing was cancelled
 			return;
 		if (!setEditorFile(openFile))
 			return;

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -211,8 +211,9 @@ public class UserInterface {
 		if (!closeCurrentOpenFile())
 			return false;
 		// Delete all content
-		monthSettingsBar.reset();
+		currentOpenFile = null;
 		listModel.clear();
+		monthSettingsBar.reset();
 		setHasUnsavedChanges(false);
 		return true;
 	}
@@ -224,7 +225,7 @@ public class UserInterface {
 	 * 
 	 * @return If proceed or not.
 	 */
-	public boolean closeCurrentOpenFile() {
+	private boolean closeCurrentOpenFile() {
 		if (!hasUnsavedChanges)
 			return true;
 		// Prompt to save
@@ -264,10 +265,9 @@ public class UserInterface {
 	public void openFile(File openFile) {
 		if (openFile == null)
 			return;
-		if (!setEditorFile(openFile))
+		if (!clearWorkspace())	// Don't proceed: Clearing was cancelled
 			return;
-		boolean proceed = clearWorkspace();
-		if (!proceed)
+		if (!setEditorFile(openFile))
 			return;
 
 		// Open the file


### PR DESCRIPTION
- Fixed a bug where break was mandatory with >= 6 hours, not > 6 hours
- Changed mandatory break for 9 hours from 60 to 45 minutes in compliance with the provided source. The TimesheetGenerator code still validates this separately when exporting. That code remains unchanged.
- Fixed a bug with ordering where the old file would not be properly cleared when navigating to File -> new, causing it to still be linked to the editor and overridden
- Fixed a bug where the title and time count would not be properly reset when navigating to File -> new
- Fixed a bug where the new open file would be overridden when opening a new file and discarding changes in the old file.
- Fixed a bug where the "New Entry" dialog would be disposed despite being invalid, causing the changes to just be discarded.
- Minor changes