### PR TITLE
Added entry optimizations + Bugfixes related to automatically selected year and default file names

### DIFF
--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -8,6 +8,8 @@ import javax.swing.text.*;
 import java.awt.*;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -221,10 +223,14 @@ public final class DialogHelper {
 		});
 
 		cancelButton.addActionListener(e -> {
-			// Since the old entry will be deleted, we need to add it back
-			if (!entry.isEmpty())
-				parentUi.addEntry(entry);
-			dialog.dispose();
+			discardChanges(entry, parentUi, dialog);
+		});
+
+		dialog.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent e) {
+				discardChanges(entry, parentUi, dialog);
+			}
 		});
 
 		// Update task summary when activity text changes
@@ -258,6 +264,13 @@ public final class DialogHelper {
 
 		dialog.add(panel);
 		dialog.setVisible(true);
+	}
+
+	private static void discardChanges(TimesheetEntry entry, UserInterface parentUi, JDialog dialog) {
+		// Since the old entry will be deleted, we need to add it back
+		if (!entry.isEmpty())
+			parentUi.addEntry(entry);
+		dialog.dispose();
 	}
 
 	/**

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -374,7 +374,7 @@ public final class DialogHelper {
 	}
 
 	private static void validateTimeField(JTextField timeField, JLabel errorLabel, boolean isBreak) {
-		String text = timeField.getText().trim();
+		String text = timeField.getText().trim().replace('.', ':');
 		if (text.equals(TIME_PLACEHOLDER) || text.equals(TIME_BREAK_PLACEHOLDER)) {
 			errorLabel.setText(" ");
 			return;
@@ -519,7 +519,11 @@ public final class DialogHelper {
 		try {
 			return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("H:mm"));
 		} catch (DateTimeParseException e) {
-			return LocalTime.of(0, 0);
+			try {
+				return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("H.mm"));
+			} catch (DateTimeParseException e1) {
+				return LocalTime.of(0, 0);
+			}
 		}
 	}
 

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -29,7 +29,7 @@ public final class DialogHelper {
 	static final Pattern TIME_PATTERN_SMALL = Pattern.compile("^(\\d{1,2})$");
 	static final Pattern TIME_PATTERN_SEMI_SMALL = Pattern.compile("^(\\d{1,2}):(\\d)$");
 
-	private static final int MAX_TEXT_LENGTH_ACTIVITY = 27;
+    private static final int MAX_TEXT_LENGTH_ACTIVITY = 30;
 	private static final int MIN_BREAK_SIX_HOURS = 30;
 	private static final int MIN_BREAK_NINE_HOURS = 45;
 
@@ -74,23 +74,20 @@ public final class DialogHelper {
 		gbc.anchor = GridBagConstraints.NORTHWEST;
 		panel.add(actionLabel, gbc);
 
-		JTextArea actionTextArea = new JTextArea(1, MAX_TEXT_LENGTH_ACTIVITY);
-		JScrollPane scrollPane = new JScrollPane(actionTextArea);
-		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
+		JTextField actionTextField = new JTextField("", MAX_TEXT_LENGTH_ACTIVITY);
 
-		addPlaceholderText(actionTextArea, "Describe the activity", entry.getActivity());
+		addPlaceholderText(actionTextField, "Describe the activity", entry.getActivity());
 		if (!entry.getActivity().isEmpty()) {
-			actionTextArea.setText(entry.getActivity());
+			actionTextField.setText(entry.getActivity());
 			taskSummaryValue.setText(entry.getActivity());
 		}
-		((AbstractDocument) actionTextArea.getDocument()).setDocumentFilter(new DocumentSizeFilter(MAX_TEXT_LENGTH_ACTIVITY));
+		((AbstractDocument) actionTextField.getDocument()).setDocumentFilter(new DocumentSizeFilter(MAX_TEXT_LENGTH_ACTIVITY));
 
 		gbc.gridx = 1;
 		gbc.gridy = row;
 		gbc.weightx = 1;
 		gbc.fill = GridBagConstraints.BOTH;
-		panel.add(scrollPane, gbc);
+		panel.add(actionTextField, gbc);
 
 		row++;
 
@@ -219,7 +216,7 @@ public final class DialogHelper {
 
 		// Action listeners for buttons
 		makeEntryButton.addActionListener(e -> {
-			if (makeEntryAction(parentUi, durationWarningLabel, actionTextArea, timeFields, vacationCheckBox))
+			if (makeEntryAction(parentUi, durationWarningLabel, actionTextField, timeFields, vacationCheckBox))
 				dialog.dispose();
 		});
 
@@ -231,7 +228,7 @@ public final class DialogHelper {
 		});
 
 		// Update task summary when activity text changes
-		actionTextArea.getDocument().addDocumentListener(new DocumentListener() {
+		actionTextField.getDocument().addDocumentListener(new DocumentListener() {
 			@Override
 			public void insertUpdate(DocumentEvent e) {
 				update();
@@ -248,10 +245,10 @@ public final class DialogHelper {
 			}
 
 			private void update() {
-				if (actionTextArea.getForeground() != Color.BLACK)
+				if (actionTextField.getForeground() != Color.BLACK)
 					return; // Not if placeholder text
-				taskSummaryValue.setText(actionTextArea.getText());
-				if (!actionTextArea.getText().isBlank() && durationWarningLabel.getText().equals(ACTIVITY_MESSAGE)) {
+				taskSummaryValue.setText(actionTextField.getText());
+				if (!actionTextField.getText().isBlank() && durationWarningLabel.getText().equals(ACTIVITY_MESSAGE)) {
 					durationWarningLabel.setText(" ");
 					updateDurationSummary(durationSummaryValue, timeFields[INDEX_START_TIME], timeFields[INDEX_END_TIME], timeFields[INDEX_BREAK_TIME],
 							durationWarningLabel, vacationCheckBox);
@@ -267,18 +264,18 @@ public final class DialogHelper {
 	 * The Action for the "Make Entry" Button in the "Add/Edit Entry" Dialog.
 	 * Returns if the dialog should be disposed (success) or if it should be kept
 	 * open (failure).
-	 * 
+	 *
 	 * @param parentUI             The parent UserInterface.
 	 * @param durationWarningLabel The warning label for the work time message.
-	 * @param actionTextArea       The text area for the activity.
+	 * @param actionTextField      The text field for the activity.
 	 * @param timeFields           The array of fields for the times.
 	 * @param vacationCheckBox     The vacation checkbox.
 	 * @return True if the dialog should be disposed, false if not.
 	 */
-	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextArea actionTextArea, JTextField[] timeFields,
+	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextField actionTextField, JTextField[] timeFields,
 			JCheckBox vacationCheckBox) {
 		if (durationWarningLabel.getText().isBlank()) {
-			if (actionTextArea.getText().isBlank()) {
+			if (actionTextField.getText().isBlank()) {
 				durationWarningLabel.setText(ACTIVITY_MESSAGE);
 			}
 			// warning label is updated automatically when fields are edited
@@ -315,7 +312,7 @@ public final class DialogHelper {
 			timeFields[INDEX_BREAK_TIME].setText("00:00");
 		}
 
-		TimesheetEntry newEntry = TimesheetEntry.generateTimesheetEntry(actionTextArea.getText(), Integer.parseInt(timeFields[INDEX_DAY].getText()),
+		TimesheetEntry newEntry = TimesheetEntry.generateTimesheetEntry(actionTextField.getText(), Integer.parseInt(timeFields[INDEX_DAY].getText()),
 				timeFields[INDEX_START_TIME].getText(), timeFields[INDEX_END_TIME].getText(), timeFields[INDEX_BREAK_TIME].getText(),
 				vacationCheckBox.isSelected());
 		parentUI.addEntry(newEntry);

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -519,11 +519,7 @@ public final class DialogHelper {
 		try {
 			return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("H:mm"));
 		} catch (DateTimeParseException e) {
-			try {
-				return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("H.mm"));
-			} catch (DateTimeParseException e1) {
-				return LocalTime.of(0, 0);
-			}
+			return LocalTime.of(0, 0);
 		}
 	}
 

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import javax.swing.*;
@@ -31,7 +31,7 @@ public final class DialogHelper {
 	static final Pattern TIME_PATTERN_SMALL = Pattern.compile("^(\\d{1,2})$");
 	static final Pattern TIME_PATTERN_SEMI_SMALL = Pattern.compile("^(\\d{1,2}):(\\d)$");
 
-    private static final int MAX_TEXT_LENGTH_ACTIVITY = 30;
+	private static final int MAX_TEXT_LENGTH_ACTIVITY = 30;
 	private static final int MIN_BREAK_SIX_HOURS = 30;
 	private static final int MIN_BREAK_NINE_HOURS = 45;
 

--- a/src/main/java/ui/JTimeField.java
+++ b/src/main/java/ui/JTimeField.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import javax.swing.*;

--- a/src/main/java/ui/JTimeField.java
+++ b/src/main/java/ui/JTimeField.java
@@ -34,19 +34,17 @@ public class JTimeField extends JTextField {
 	}
 
 	private void validateField() {
-		String text = this.getText();
+		String text = this.getText().trim().replace('.', ':');
 
 		if (DialogHelper.TIME_PATTERN_SMALL.matcher(text).matches()) {
 			text += ":00";
-			super.setText(text);
 		} else if (DialogHelper.TIME_PATTERN_SEMI_SMALL.matcher(text).matches()) {
 			text += "0";
-			super.setText(text);
 		}
 		if (TIME_PATTERN_SEMI_SMALL_2.matcher(text).matches()) {
 			text = "0" + text;
-			super.setText(text);
 		}
+		super.setText(text);
 
 		if (!text.isBlank() && !DialogHelper.TIME_PATTERN.matcher(text).matches()) {
 			setForeground(Color.RED);

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -125,9 +125,17 @@ public class MonthlySettingsBar extends JPanel {
 
 	public String getYear() {
 		if (semesterTextField.getForeground() == Color.BLACK && !semesterTextField.getText().isBlank()) {
-			return semesterTextField.getText();
+			// Winter semester
+			int year;
+			try {
+				year = Integer.parseInt(semesterTextField.getText());
+			} catch (NumberFormatException e) {
+				return DateTimeFormatter.ofPattern("yy").format(LocalDateTime.now());
+			}
+			if (getSelectedMonthNumber() < 6) year++;	// New year
+			return String.valueOf(year);
 		}
-		return DateTimeFormatter.ofPattern("yy").format(LocalDateTime.now());
+		return semesterTextField.getText();
 	}
 
 	public Time getPredTime() {

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import ui.json.Month;
@@ -132,7 +132,8 @@ public class MonthlySettingsBar extends JPanel {
 			} catch (NumberFormatException e) {
 				return DateTimeFormatter.ofPattern("yy").format(LocalDateTime.now());
 			}
-			if (getSelectedMonthNumber() < 6) year++;	// New year
+			if (getSelectedMonthNumber() < 6)
+				year++; // New year
 			return String.valueOf(year);
 		}
 		return semesterTextField.getText();


### PR DESCRIPTION
- Fixed a bug where dismissing the edit dialog in the top left/right corner would delete the entry
- Fixed bugs related to the wrong year being chosen when either saving, exporting or opening up a new file
  -> This has been adjusted to account for early winter (higher year number) or late winter (lower year number) as winter semester has two years
- Changed type of Activity from TextArea to TextField to allow switching with the tab button
- Made time fields accept `.` as `:`, just out of convenience
- Other minor changes

Unfortunately, I can't run spotless:apply because I get some internal error, "Text is not in XZ format", unable to fix after updating everything.