### PR TITLE
Feature/more options and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ buildNumber.properties
 *.iml
 .DS_Store
 .vscode
+MANIFEST.MF

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>pdfbox</artifactId>
             <version>3.0.5</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -107,4 +107,8 @@ public class ActionBar extends JPanel {
 		return successorHours;
 	}
 
+	public void reset() {
+		updateHours(new Time());
+	}
+
 }

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -3,6 +3,7 @@ package ui;
 
 import ui.export.FileExporter;
 import ui.json.JSONHandler;
+import ui.json.UISettings;
 
 import javax.swing.*;
 import java.awt.*;
@@ -85,22 +86,28 @@ public class ActionBar extends JPanel {
 	 * @return Overflowing hours.
 	 */
 	public Time updateHours(Time workedHours) {
+		UISettings uiSettings = JSONHandler.getUISettings();
 		String totalHoursStr = JSONHandler.getGlobalSettings().getWorkingTime();
 		Time totalHours = Time.parseTime(totalHoursStr);
 
 		workedHours.addTime(this.parentUi.getPredTime());
 
-		Time displayedWorkedHours;
+		String displayedWorkedHours;
 		Time successorHours;
 
 		if (workedHours.isLongerThan(totalHours)) {
-			displayedWorkedHours = totalHours;
+			displayedWorkedHours = totalHours + "+";
 			successorHours = new Time(workedHours);
 			successorHours.subtractTime(totalHours);
 			hoursWorkedLabel.setFont(fontBold);
+
+			if (uiSettings.isWarnOnHoursMismatch()) {
+				hoursWorkedLabel.setForeground(Color.RED);
+			}
 		} else {
-			displayedWorkedHours = workedHours;
+			displayedWorkedHours = workedHours.toString();
 			successorHours = new Time(0, 0);
+			hoursWorkedLabel.setForeground(Color.BLACK);
 
 			// Same Length
 			if (!totalHours.isLongerThan(workedHours))

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -84,8 +84,8 @@ public class ActionBar extends JPanel {
 	}
 
 	private boolean hourMismatchCheck() {
-		return (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch() && !parentUi.showOKCancelDialog("Hours mismatch",
-				"Warning: The worked hours do not match the target working hours. Do you want to continue?"));
+		return (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch()
+				&& !parentUi.showOKCancelDialog("Hours mismatch", "Warning: The worked hours do not match the target working hours. Do you want to continue?"));
 	}
 
 	/**

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import ui.export.FileExporter;
@@ -63,8 +63,8 @@ public class ActionBar extends JPanel {
 
 		compileButton.addActionListener(l -> FileExporter.printTex(this.parentUi));
 		printButton.addActionListener(l -> {
-			if (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch()
-				&& !parentUi.showOKCancelDialog("Hours mismatch", "Warning: The worked hours do not match the target working hours. Do you want to continue?")) {
+			if (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch() && !parentUi.showOKCancelDialog("Hours mismatch",
+					"Warning: The worked hours do not match the target working hours. Do you want to continue?")) {
 				return;
 			}
 			FileExporter.printPDF(this.parentUi);

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -30,23 +30,23 @@ public class ActionBar extends JPanel {
 		buttonPanel.add(addButton);
 
 		JButton duplicateButton = new JButton("Duplicate");
-		duplicateButton.setPreferredSize(new Dimension(90, 50));
+		duplicateButton.setPreferredSize(new Dimension(100, 50));
 		buttonPanel.add(duplicateButton);
 
 		JButton editButton = new JButton("Edit");
-		editButton.setPreferredSize(new Dimension(60, 50));
+		editButton.setPreferredSize(new Dimension(70, 50));
 		buttonPanel.add(editButton);
 
 		JButton removeButton = new JButton("Remove");
-		removeButton.setPreferredSize(new Dimension(90, 50));
+		removeButton.setPreferredSize(new Dimension(100, 50));
 		buttonPanel.add(removeButton);
 
 		JButton compileButton = new JButton("Compile to Tex");
-		compileButton.setPreferredSize(new Dimension(110, 50));
+		compileButton.setPreferredSize(new Dimension(125, 50));
 		buttonPanel.add(compileButton);
 
 		JButton printButton = new JButton("Print to PDF");
-		printButton.setPreferredSize(new Dimension(95, 50));
+		printButton.setPreferredSize(new Dimension(105, 50));
 		buttonPanel.add(printButton);
 
 		this.add(buttonPanel, BorderLayout.WEST);

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -62,7 +62,13 @@ public class ActionBar extends JPanel {
 		editButton.addActionListener(l -> this.parentUi.editSelectedListEntry());
 
 		compileButton.addActionListener(l -> FileExporter.printTex(this.parentUi));
-		printButton.addActionListener(l -> FileExporter.printPDF(this.parentUi));
+		printButton.addActionListener(l -> {
+			if (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch()
+				&& !parentUi.showOKCancelDialog("Hours mismatch", "Warning: The worked hours do not match the target working hours. Do you want to continue?")) {
+				return;
+			}
+			FileExporter.printPDF(this.parentUi);
+		});
 
 		hoursWorkedLabel = new JLabel();
 		fontNormal = hoursWorkedLabel.getFont().deriveFont(18f);

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -62,10 +62,14 @@ public class ActionBar extends JPanel {
 		removeButton.addActionListener(l -> this.parentUi.removeSelectedListEntry());
 		editButton.addActionListener(l -> this.parentUi.editSelectedListEntry());
 
-		compileButton.addActionListener(l -> FileExporter.printTex(this.parentUi));
+		compileButton.addActionListener(l -> {
+			if (hourMismatchCheck()) {
+				return;
+			}
+			FileExporter.printTex(this.parentUi);
+		});
 		printButton.addActionListener(l -> {
-			if (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch() && !parentUi.showOKCancelDialog("Hours mismatch",
-					"Warning: The worked hours do not match the target working hours. Do you want to continue?")) {
+			if (hourMismatchCheck()) {
 				return;
 			}
 			FileExporter.printPDF(this.parentUi);
@@ -77,6 +81,11 @@ public class ActionBar extends JPanel {
 		hoursWorkedLabel.setFont(fontNormal);
 		this.add(hoursWorkedLabel, BorderLayout.EAST);
 		updateHours(new Time());
+	}
+
+	private boolean hourMismatchCheck() {
+		return (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch() && !parentUi.showOKCancelDialog("Hours mismatch",
+				"Warning: The worked hours do not match the target working hours. Do you want to continue?"));
 	}
 
 	/**

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -21,7 +21,7 @@ public final class GlobalSettingsDialog {
 
 	private static final int SCROLL_SENSITIVITY = 16;
 
-	public static void showGlobalSettingsDialog() {
+	public static void showGlobalSettingsDialog(UserInterface parentUI) {
 		JDialog dialog = new JDialog();
 		dialog.setTitle("Global Settings");
 		dialog.setSize(600, 485);
@@ -184,6 +184,8 @@ public final class GlobalSettingsDialog {
 			// Save globalSettings to file or database as needed
 			JSONHandler.saveGlobal(globalSettings);
 			JSONHandler.saveUISettings(uiSettings);
+
+			parentUI.updateTotalTimeWorkedUI();
 
 			dialog.dispose();
 		});

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import ui.json.Global;
@@ -9,7 +9,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
-import java.util.Arrays;
 
 public final class GlobalSettingsDialog {
 
@@ -65,7 +64,8 @@ public final class GlobalSettingsDialog {
 
 		final int TEXTBOXES_COUNT = 5;
 
-		String[] labels = { "Name:", "Staff ID:", "Department:", "Working Time:", "Wage:", "Working Area:", "Add Signature at Bottom:", "Explicitly add Vacation Entry:", "Use 4-digit year:", "Use German month names", "Warn when too few/ too many hours:" };
+		String[] labels = { "Name:", "Staff ID:", "Department:", "Working Time:", "Wage:", "Working Area:", "Add Signature at Bottom:",
+				"Explicitly add Vacation Entry:", "Use 4-digit year:", "Use German month names", "Warn when too few/ too many hours:" };
 		String[] placeholders = { "Enter your name", "Enter your staff ID", "Enter your department", "Enter working time (HH:MM)", "Enter your wage" };
 		String[] initialValues = { globalSettings.getName(), String.valueOf(globalSettings.getStaffId()), globalSettings.getDepartment(),
 				globalSettings.getWorkingTime(), String.valueOf(globalSettings.getWage()) };

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -65,7 +65,7 @@ public final class GlobalSettingsDialog {
 		final int TEXTBOXES_COUNT = 5;
 
 		String[] labels = { "Name:", "Staff ID:", "Department:", "Working Time:", "Wage:", "Working Area:", "Add Signature at Bottom:",
-				"Explicitly add Vacation Entry:", "Use 4-digit year:", "Use German month names", "Warn when too few/ too many hours:" };
+				"Explicitly add Vacation Entry:", "Use 4-digit year in the day column:", "Use German month names", "Warn when too few/ too many hours:" };
 		String[] placeholders = { "Enter your name", "Enter your staff ID", "Enter your department", "Enter working time (HH:MM)", "Enter your wage" };
 		String[] initialValues = { globalSettings.getName(), String.valueOf(globalSettings.getStaffId()), globalSettings.getDepartment(),
 				globalSettings.getWorkingTime(), String.valueOf(globalSettings.getWage()) };

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -48,7 +48,7 @@ public final class GlobalSettingsDialog {
 		workAreaSelector.addItem(WORK_AREA_GF);
 		workAreaSelector.setSelectedIndex(getIndexValue(globalSettings.getWorkingArea()));
 		JCheckBox addSignatureBox = new JCheckBox();
-		addSignatureBox.setSelected(uiSettings.getAddSignature());
+		addSignatureBox.setSelected(uiSettings.isAddSignature());
 
 		String[] labels = { "Name:", "Staff ID:", "Department:", "Working Time:", "Wage:", "Working Area:", "Add Signature at Bottom:" };
 		String[] placeholders = { "Enter your name", "Enter your staff ID", "Enter your department", "Enter working time (HH:MM)", "Enter your wage" };

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -193,8 +193,8 @@ public final class GlobalSettingsDialog {
 		cancelButton.addActionListener(e -> dialog.dispose());
 
 		JScrollPane scrollPanel = new JScrollPane(panel);
-		scrollPanel.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-		scrollPanel.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+		scrollPanel.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollPanel.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		scrollPanel.getVerticalScrollBar().setUnitIncrement(SCROLL_SENSITIVITY);
 		dialog.add(scrollPanel);
 		dialog.setVisible(true);

--- a/src/main/java/ui/JTimeField.java
+++ b/src/main/java/ui/JTimeField.java
@@ -53,6 +53,14 @@ public class JTimeField extends JTextField {
 		}
 	}
 
+	public void clear() {
+		// Prevent auto-focus on clear
+		super.setFocusable(false);
+		super.setText(PLACEHOLDER);
+		setForeground(Color.GRAY);
+		super.setFocusable(true);
+	}
+
 	@Override
 	public boolean isValid() {
 		return getForeground() != Color.RED;

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -10,12 +10,13 @@ import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 public class MonthlySettingsBar extends JPanel {
 
 	private static final String[] MONTHS = new String[] { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October",
 			"November", "December" };
+
+	private int YEAR_OFFSET = 2000;
 
 	private final transient UserInterface parentUi;
 
@@ -123,20 +124,26 @@ public class MonthlySettingsBar extends JPanel {
 		return monthSelector.getSelectedIndex() + 1;
 	}
 
-	public String getYear() {
-		if (getSelectedMonthNumber() < 4 || getSelectedMonthNumber() > 9) {
-			// Winter semester
-			int year;
-			try {
-				year = Integer.parseInt(semesterTextField.getText());
-			} catch (NumberFormatException e) {
-				year = LocalDateTime.now().getYear() % 2000;
-			}
-			if (getSelectedMonthNumber() < 6)
-				year++; // New year
-			return String.valueOf(year);
+	private int getFullYear() {
+		return getYear() + YEAR_OFFSET;
+	}
+
+	private int getYear() {
+		int year;
+		try {
+			year = Integer.parseInt(semesterTextField.getText());
+		} catch (NumberFormatException e) {
+			year = LocalDateTime.now().getYear() % 2000;
 		}
-		return semesterTextField.getText();
+		if (getSelectedMonthNumber() < 4) {
+			// Winter semester, new year
+			year++;
+		}
+		return year;
+	}
+
+	public String getYearStr() {
+		return String.valueOf(getYear());
 	}
 
 	public Time getPredTime() {
@@ -149,6 +156,8 @@ public class MonthlySettingsBar extends JPanel {
 
 	public void reset() {
 		setTimeFromCurrentDate();
+		setSuccTime("00:00");
+		predTimeField.clear();
 	}
 
 	public void importMonthSettings(Month month) {
@@ -166,8 +175,7 @@ public class MonthlySettingsBar extends JPanel {
 	}
 
 	public void fillMonth(Month month) {
-		month.setYear(2000 + Integer.parseInt(semesterTextField.getText())
-		+ (monthSelector.getSelectedIndex() < 3 ? 1 : 0));
+		month.setYear(getFullYear());
 		month.setMonth(monthSelector.getSelectedIndex() + 1);
 		month.setPredTransfer(predTimeField.getText());
 		month.setSuccTransfer(succTimeValue.getText());

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -190,7 +190,8 @@ public class MonthlySettingsBar extends JPanel {
 			semesterSelector.setSelectedIndex(0);
 		} else {
 			semesterSelector.setSelectedIndex(1);
-			if (month < 4) year--;
+			if (month < 4)
+				year--;
 		}
 		String yearStr = String.valueOf(year);
 		semesterTextField.setText(yearStr.substring(yearStr.length() - 2));

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -29,8 +29,8 @@ public class MonthlySettingsBar extends JPanel {
 	private final JLabel succTimeLabel;
 	private final JLabel succTimeValue;
 
-	private final Font FONT_NORMAL;
-	private final Font FONT_BOLD;
+	private final Font fontNormal;
+	private final Font fontBold;
 
 	public MonthlySettingsBar(UserInterface parentUi) {
 		super(new BorderLayout());
@@ -84,8 +84,8 @@ public class MonthlySettingsBar extends JPanel {
 		succTimeValue.setText("00:00");
 		timeCarryPanel.add(succTimeValue);
 
-		FONT_NORMAL = succTimeValue.getFont();
-		FONT_BOLD = FONT_NORMAL.deriveFont(Font.BOLD);
+		fontNormal = succTimeValue.getFont();
+		fontBold = fontNormal.deriveFont(Font.BOLD);
 
 		this.add(timeCarryPanel, BorderLayout.CENTER);
 
@@ -163,14 +163,14 @@ public class MonthlySettingsBar extends JPanel {
 		if (JSONHandler.getUISettings().isWarnOnHoursMismatch()) {
 			if (time.isNotZero()) {
 				succTimeValue.setForeground(Color.RED);
-				succTimeValue.setFont(FONT_BOLD);
+				succTimeValue.setFont(fontBold);
 				succTimeLabel.setForeground(Color.RED);
-				succTimeLabel.setFont(FONT_BOLD);
+				succTimeLabel.setFont(fontBold);
 			} else {
 				succTimeValue.setForeground(Color.BLACK);
-				succTimeValue.setFont(FONT_NORMAL);
+				succTimeValue.setFont(fontNormal);
 				succTimeLabel.setForeground(Color.BLACK);
-				succTimeLabel.setFont(FONT_NORMAL);
+				succTimeLabel.setFont(fontNormal);
 			}
 		}
 	}

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024-2025. */
 package ui;
 
+import ui.json.JSONHandler;
 import ui.json.Month;
 
 import javax.swing.*;
@@ -16,7 +17,7 @@ public class MonthlySettingsBar extends JPanel {
 	private static final String[] MONTHS = new String[] { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October",
 			"November", "December" };
 
-	private int YEAR_OFFSET = 2000;
+	private static final int YEAR_OFFSET = 2000;
 
 	private final transient UserInterface parentUi;
 
@@ -25,7 +26,11 @@ public class MonthlySettingsBar extends JPanel {
 	private final JTextField semesterTextField;
 	private final JLabel semesterTextFieldLabel;
 	private final JTimeField predTimeField;
+	private final JLabel succTimeLabel;
 	private final JLabel succTimeValue;
+
+	private final Font FONT_NORMAL;
+	private final Font FONT_BOLD;
 
 	public MonthlySettingsBar(UserInterface parentUi) {
 		super(new BorderLayout());
@@ -70,14 +75,17 @@ public class MonthlySettingsBar extends JPanel {
 		timeCarryPanel.add(predTimeField);
 
 		// Pred. Time
-		JLabel succTimeLabel = new JLabel();
+		succTimeLabel = new JLabel();
 		succTimeLabel.setText("    Successor Time: ");
 		timeCarryPanel.add(succTimeLabel);
 
-		// Pred. Time
+		// Succ. Time
 		succTimeValue = new JLabel();
 		succTimeValue.setText("00:00");
 		timeCarryPanel.add(succTimeValue);
+
+		FONT_NORMAL = succTimeValue.getFont();
+		FONT_BOLD = FONT_NORMAL.deriveFont(Font.BOLD);
 
 		this.add(timeCarryPanel, BorderLayout.CENTER);
 
@@ -110,7 +118,7 @@ public class MonthlySettingsBar extends JPanel {
 			updateSemesterView();
 		});
 
-		settingsButton.addActionListener(l -> GlobalSettingsDialog.showGlobalSettingsDialog());
+		settingsButton.addActionListener(l -> GlobalSettingsDialog.showGlobalSettingsDialog(parentUi));
 	}
 
 	public String getSelectedMonthName() {
@@ -150,13 +158,26 @@ public class MonthlySettingsBar extends JPanel {
 		return predTimeField.isValid() ? Time.parseTime(predTimeField.getText()) : new Time(0, 0);
 	}
 
-	public void setSuccTime(String time) {
-		succTimeValue.setText(time);
+	public void setSuccTime(Time time) {
+		succTimeValue.setText(time.toString());
+		if (JSONHandler.getUISettings().isWarnOnHoursMismatch()) {
+			if (time.isNotZero()) {
+				succTimeValue.setForeground(Color.RED);
+				succTimeValue.setFont(FONT_BOLD);
+				succTimeLabel.setForeground(Color.RED);
+				succTimeLabel.setFont(FONT_BOLD);
+			} else {
+				succTimeValue.setForeground(Color.BLACK);
+				succTimeValue.setFont(FONT_NORMAL);
+				succTimeLabel.setForeground(Color.BLACK);
+				succTimeLabel.setFont(FONT_NORMAL);
+			}
+		}
 	}
 
 	public void reset() {
 		setTimeFromCurrentDate();
-		setSuccTime("00:00");
+		setSuccTime(new Time());
 		predTimeField.clear();
 	}
 

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -130,7 +130,7 @@ public class MonthlySettingsBar extends JPanel {
 			try {
 				year = Integer.parseInt(semesterTextField.getText());
 			} catch (NumberFormatException e) {
-				return DateTimeFormatter.ofPattern("yy").format(LocalDateTime.now());
+				year = LocalDateTime.now().getYear() % 2000;
 			}
 			if (getSelectedMonthNumber() < 6)
 				year++; // New year

--- a/src/main/java/ui/MonthlySettingsBar.java
+++ b/src/main/java/ui/MonthlySettingsBar.java
@@ -124,7 +124,7 @@ public class MonthlySettingsBar extends JPanel {
 	}
 
 	public String getYear() {
-		if (semesterTextField.getForeground() == Color.BLACK && !semesterTextField.getText().isBlank()) {
+		if (getSelectedMonthNumber() < 4 || getSelectedMonthNumber() > 9) {
 			// Winter semester
 			int year;
 			try {
@@ -166,7 +166,8 @@ public class MonthlySettingsBar extends JPanel {
 	}
 
 	public void fillMonth(Month month) {
-		month.setYear(2000 + Integer.parseInt(semesterTextField.getText()));
+		month.setYear(2000 + Integer.parseInt(semesterTextField.getText())
+		+ (monthSelector.getSelectedIndex() < 3 ? 1 : 0));
 		month.setMonth(monthSelector.getSelectedIndex() + 1);
 		month.setPredTransfer(predTimeField.getText());
 		month.setSuccTransfer(succTimeValue.getText());
@@ -176,13 +177,15 @@ public class MonthlySettingsBar extends JPanel {
 		LocalDateTime time = LocalDateTime.now();
 		int month = time.getMonthValue();
 		monthSelector.setSelectedIndex(month - 1);
+		int year = time.getYear();
 		if (month >= 4 && month <= 9) {
 			semesterSelector.setSelectedIndex(0);
 		} else {
 			semesterSelector.setSelectedIndex(1);
+			if (month < 4) year--;
 		}
-		String year = String.valueOf(time.getYear());
-		semesterTextField.setText(year.substring(year.length() - 2));
+		String yearStr = String.valueOf(year);
+		semesterTextField.setText(yearStr.substring(yearStr.length() - 2));
 		updateSemesterView();
 	}
 

--- a/src/main/java/ui/Time.java
+++ b/src/main/java/ui/Time.java
@@ -67,6 +67,10 @@ public class Time {
 		return this.minutes > other.minutes;
 	}
 
+	public boolean isNotZero() {
+		return hours > 0 || minutes > 0;
+	}
+
 	public static Time parseTime(String string) {
 		if (string == null)
 			return new Time(0, 0);

--- a/src/main/java/ui/Time.java
+++ b/src/main/java/ui/Time.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import lombok.Getter;
@@ -9,7 +9,7 @@ import java.util.regex.Matcher;
 @Getter
 public class Time {
 	@Setter
-    private int hours;
+	private int hours;
 	private int minutes;
 
 	public Time() {
@@ -26,11 +26,11 @@ public class Time {
 		setMinutes(time.getMinutes());
 	}
 
-    public void addHours(int hours) {
+	public void addHours(int hours) {
 		this.hours += hours;
 	}
 
-    public void setMinutes(int minutes) {
+	public void setMinutes(int minutes) {
 		this.hours += minutes / 60;
 		this.minutes = minutes % 60;
 	}

--- a/src/main/java/ui/Time.java
+++ b/src/main/java/ui/Time.java
@@ -1,10 +1,15 @@
 /* Licensed under MIT 2024. */
 package ui;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.regex.Matcher;
 
+@Getter
 public class Time {
-	private int hours;
+	@Setter
+    private int hours;
 	private int minutes;
 
 	public Time() {
@@ -21,23 +26,11 @@ public class Time {
 		setMinutes(time.getMinutes());
 	}
 
-	public int getHours() {
-		return hours;
-	}
-
-	public void setHours(int hours) {
-		this.hours = hours;
-	}
-
-	public void addHours(int hours) {
+    public void addHours(int hours) {
 		this.hours += hours;
 	}
 
-	public int getMinutes() {
-		return minutes;
-	}
-
-	public void setMinutes(int minutes) {
+    public void setMinutes(int minutes) {
 		this.hours += minutes / 60;
 		this.minutes = minutes % 60;
 	}

--- a/src/main/java/ui/Time.java
+++ b/src/main/java/ui/Time.java
@@ -55,6 +55,10 @@ public class Time {
 		addMinutes(-time.getMinutes());
 	}
 
+	public boolean sameLengthAs(Time other) {
+		return this.hours == other.hours && this.minutes == other.minutes;
+	}
+
 	public boolean isLongerThan(Time other) {
 		if (this.hours > other.hours)
 			return true;

--- a/src/main/java/ui/TimesheetEntry.java
+++ b/src/main/java/ui/TimesheetEntry.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import lombok.Getter;
@@ -18,7 +18,7 @@ public class TimesheetEntry {
 	public static final TimesheetEntry EMPTY_ENTRY = new TimesheetEntry("", -1, Time.none(), Time.none(), Time.none(), false);
 
 	@Getter
-    private final String activity;
+	private final String activity;
 	private final int day;
 	private final int fromHour;
 	private final int fromMinute;
@@ -27,7 +27,7 @@ public class TimesheetEntry {
 	private final int breakHour;
 	private final int breakMinutes;
 	@Getter
-    private final boolean isVacation;
+	private final boolean isVacation;
 
 	public static TimesheetEntry generateTimesheetEntry(String activity, int day, String startText, String endText, String breakText, boolean isVacation) {
 		LocalTime parsedStartTime = DialogHelper.parseTime(startText);
@@ -126,7 +126,7 @@ public class TimesheetEntry {
 		return entry;
 	}
 
-    public String getDayString() {
+	public String getDayString() {
 		if (day == -1)
 			return "";
 		return String.format("%02d", day);
@@ -172,7 +172,7 @@ public class TimesheetEntry {
 		return new Time((int) workDuration.toHours(), (int) workDuration.toMinutes() % 60);
 	}
 
-    public String isVacationStr() {
+	public String isVacationStr() {
 		return isVacation ? "yes" : "no";
 	}
 

--- a/src/main/java/ui/TimesheetEntry.java
+++ b/src/main/java/ui/TimesheetEntry.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024. */
 package ui;
 
+import lombok.Getter;
 import ui.json.Month;
 
 import java.time.Duration;
@@ -16,7 +17,8 @@ public class TimesheetEntry {
 
 	public static final TimesheetEntry EMPTY_ENTRY = new TimesheetEntry("", -1, Time.none(), Time.none(), Time.none(), false);
 
-	private final String activity;
+	@Getter
+    private final String activity;
 	private final int day;
 	private final int fromHour;
 	private final int fromMinute;
@@ -24,7 +26,8 @@ public class TimesheetEntry {
 	private final int toMinute;
 	private final int breakHour;
 	private final int breakMinutes;
-	private final boolean isVacation;
+	@Getter
+    private final boolean isVacation;
 
 	public static TimesheetEntry generateTimesheetEntry(String activity, int day, String startText, String endText, String breakText, boolean isVacation) {
 		LocalTime parsedStartTime = DialogHelper.parseTime(startText);
@@ -123,11 +126,7 @@ public class TimesheetEntry {
 		return entry;
 	}
 
-	public String getActivity() {
-		return activity;
-	}
-
-	public String getDayString() {
+    public String getDayString() {
 		if (day == -1)
 			return "";
 		return String.format("%02d", day);
@@ -173,11 +172,7 @@ public class TimesheetEntry {
 		return new Time((int) workDuration.toHours(), (int) workDuration.toMinutes() % 60);
 	}
 
-	public boolean isVacation() {
-		return isVacation;
-	}
-
-	public String isVacationStr() {
+    public String isVacationStr() {
 		return isVacation ? "yes" : "no";
 	}
 

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024. */
 package ui;
 
+import lombok.Getter;
 import ui.fileexplorer.FileChooser;
 import ui.fileexplorer.FileChooserType;
 import ui.json.JSONHandler;
@@ -23,7 +24,8 @@ public class UserInterface {
 	private static final String APP_NAME = "Timesheet Generator";
 	private static final String TITLE = "%s: %s";
 
-	private File currentOpenFile;
+	@Getter
+    private File currentOpenFile;
 	private boolean hasUnsavedChanges = false;
 
 	private JFrame frame;
@@ -180,11 +182,7 @@ public class UserInterface {
 		return monthSettingsBar.getYear();
 	}
 
-	public File getCurrentOpenFile() {
-		return currentOpenFile;
-	}
-
-	public boolean hasUnsavedChanges() {
+    public boolean hasUnsavedChanges() {
 		return hasUnsavedChanges;
 	}
 

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui;
 
 import lombok.Getter;
@@ -25,7 +25,7 @@ public class UserInterface {
 	private static final String TITLE = "%s: %s";
 
 	@Getter
-    private File currentOpenFile;
+	private File currentOpenFile;
 	private boolean hasUnsavedChanges = false;
 
 	private JFrame frame;
@@ -182,7 +182,7 @@ public class UserInterface {
 		return monthSettingsBar.getYearStr();
 	}
 
-    public boolean hasUnsavedChanges() {
+	public boolean hasUnsavedChanges() {
 		return hasUnsavedChanges;
 	}
 

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -373,6 +373,7 @@ public class UserInterface {
 		setHasUnsavedChanges(true);
 		listModel.removeElementAt(selectedItemIndex);
 		itemList.setSelectedIndex(-1);
+		updateTotalTimeWorkedUI();
 	}
 
 	public void updateTotalTimeWorkedUI() {

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -194,6 +194,13 @@ public class UserInterface {
 		return monthSettingsBar.getPredTime();
 	}
 
+	public boolean hasWorkedHoursMismatch() {
+		// Option 1: worked too little -> Time of action bar will not match
+		Time targetWorkingTime = Time.parseTime(JSONHandler.getGlobalSettings().getWorkingTime());
+		Time actualWorkingTime = calculateTotalTimeWorked();
+		return !targetWorkingTime.sameLengthAs(actualWorkingTime);
+	}
+
 	public int getWidth() {
 		return frame.getWidth();
 	}
@@ -390,7 +397,7 @@ public class UserInterface {
 		return workedTime;
 	}
 
-	private boolean showOKCancelDialog(String title, String message) {
+	public boolean showOKCancelDialog(String title, String message) {
 		int result = JOptionPane.showConfirmDialog(frame, message, title, JOptionPane.OK_CANCEL_OPTION);
 		return JOptionPane.OK_OPTION == result;
 	}

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -179,7 +179,7 @@ public class UserInterface {
 	}
 
 	public String getYear() {
-		return monthSettingsBar.getYear();
+		return monthSettingsBar.getYearStr();
 	}
 
     public boolean hasUnsavedChanges() {
@@ -212,6 +212,7 @@ public class UserInterface {
 		currentOpenFile = null;
 		listModel.clear();
 		monthSettingsBar.reset();
+		buttonActionBar.reset();
 		setHasUnsavedChanges(false);
 		return true;
 	}

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -130,7 +130,7 @@ public class UserInterface {
 
 		fileOptionNew.addActionListener(e -> clearWorkspace());
 		fileOptionOpen.addActionListener(e -> openFile());
-		fileOptionGlobalSettings.addActionListener(e -> GlobalSettingsDialog.showGlobalSettingsDialog());
+		fileOptionGlobalSettings.addActionListener(e -> GlobalSettingsDialog.showGlobalSettingsDialog(this));
 		fileOptionSave.addActionListener(e -> saveFile(currentOpenFile));
 		fileOptionSaveAs.addActionListener(e -> saveFileAs());
 
@@ -385,7 +385,7 @@ public class UserInterface {
 	public void updateTotalTimeWorkedUI() {
 		Time worked = calculateTotalTimeWorked();
 		Time succTime = buttonActionBar.updateHours(worked);
-		monthSettingsBar.setSuccTime(succTime.toString());
+		monthSettingsBar.setSuccTime(succTime);
 	}
 
 	private Time calculateTotalTimeWorked() {
@@ -397,6 +397,7 @@ public class UserInterface {
 		return workedTime;
 	}
 
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	public boolean showOKCancelDialog(String title, String message) {
 		int result = JOptionPane.showConfirmDialog(frame, message, title, JOptionPane.OK_CANCEL_OPTION);
 		return JOptionPane.OK_OPTION == result;

--- a/src/main/java/ui/export/FileExporter.java
+++ b/src/main/java/ui/export/FileExporter.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.export;
 
 import ui.ErrorHandler;

--- a/src/main/java/ui/export/FileExporter.java
+++ b/src/main/java/ui/export/FileExporter.java
@@ -56,7 +56,7 @@ public final class FileExporter {
 				return; // Cancelled
 			}
 
-			error = PDFCompiler.compileToPDF(JSONHandler.getGlobalSettings(), parentUi.getCurrentMonth(), pdfFile);
+			error = PDFCompiler.compileToPDF(JSONHandler.getGlobalSettings(), parentUi.getCurrentMonth(), pdfFile, JSONHandler.getUISettings());
 
 			if (error.isPresent()) {
 				error("PDF compiler error", error.get());

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -71,7 +71,7 @@ public class PDFCompiler {
 
 		try {
 			form.getField("Ich bestätige die Richtigkeit der Angaben")
-					.setValue("%s, %s".formatted(DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDateTime.now()),
+					.setValue("%s, %s".formatted(DateTimeFormatter.ofPattern(DATE_FORMAT_4_DIGITS).format(LocalDateTime.now()),
 							JSONHandler.getUISettings().isAddSignature() ? global.getName() : ""));
 		} catch (EOFException ignored) {
 			Logger.getGlobal().warning("Could not load font for signature field when exporting to PDF. Proceeding with default.");

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -45,7 +45,7 @@ public class PDFCompiler {
 		}
 
 		form.getField("GF").setValue(global.getNameFormalFormat()); // Name
-		form.getField("abc").setValue(String.valueOf(month.getMonth())); // Month
+		form.getField("abc").setValue("%02d".formatted(month.getMonth())); // Month
 		form.getField("abdd").setValue(String.valueOf(month.getYear())); // Year
 		form.getField("Personalnummer").setValue(String.valueOf(global.getStaffId())); // Personalnummer
 		if (global.getWorkingArea().equals("gf")) {

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.export;
 
 import org.apache.pdfbox.Loader;
@@ -89,7 +89,8 @@ public class PDFCompiler {
 
 			if (entry.isVacation()) {
 				timeVacation.addTime(time);
-				if (!uiSettings.isAddVacationEntry()) continue;
+				if (!uiSettings.isAddVacationEntry())
+					continue;
 			}
 
 			form.getField("Tätigkeit Stichwort ProjektRow%d".formatted(fieldIndex)).setValue(entry.getAction());
@@ -100,7 +101,8 @@ public class PDFCompiler {
 			form.getField("hhmmRow%d_3".formatted(fieldIndex)).setValue(entry.getPause());
 
 			String timeFieldValue = time.toString();
-			if (entry.isVacation()) timeFieldValue += " U";
+			if (entry.isVacation())
+				timeFieldValue += " U";
 			form.getField("hhmmRow%d_4".formatted(fieldIndex)).setValue(timeFieldValue);
 			fieldIndex++;
 		}

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -89,7 +89,7 @@ public class PDFCompiler {
 
 			if (entry.isVacation()) {
 				timeVacation.addTime(time);
-				continue;
+				if (!uiSettings.isAddVacationEntry()) continue;
 			}
 
 			form.getField("Tätigkeit Stichwort ProjektRow%d".formatted(fieldIndex)).setValue(entry.getAction());
@@ -100,6 +100,7 @@ public class PDFCompiler {
 			form.getField("hhmmRow%d_3".formatted(fieldIndex)).setValue(entry.getPause());
 
 			String timeFieldValue = time.toString();
+			if (entry.isVacation()) timeFieldValue += " U";
 			form.getField("hhmmRow%d_4".formatted(fieldIndex)).setValue(timeFieldValue);
 			fieldIndex++;
 		}

--- a/src/main/java/ui/export/PDFCompiler.java
+++ b/src/main/java/ui/export/PDFCompiler.java
@@ -69,7 +69,7 @@ public class PDFCompiler {
 		try {
 			form.getField("Ich bestätige die Richtigkeit der Angaben")
 					.setValue("%s, %s".formatted(DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDateTime.now()),
-							JSONHandler.getUISettings().getAddSignature() ? global.getName() : ""));
+							JSONHandler.getUISettings().isAddSignature() ? global.getName() : ""));
 		} catch (EOFException ignored) {
 			Logger.getGlobal().warning("Could not load font for signature field when exporting to PDF. Proceeding with default.");
 		}

--- a/src/main/java/ui/export/TempFiles.java
+++ b/src/main/java/ui/export/TempFiles.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.export;
 
 import lombok.Getter;
@@ -10,9 +10,9 @@ import java.io.File;
 class TempFiles implements AutoCloseable {
 
 	@Getter
-    private final File globalFile;
+	private final File globalFile;
 	@Getter
-    private final File monthFile;
+	private final File monthFile;
 
 	private final boolean isTempMonthFile;
 
@@ -22,7 +22,7 @@ class TempFiles implements AutoCloseable {
 		this.isTempMonthFile = isTempMonthFile;
 	}
 
-    @Override
+	@Override
 	public void close() {
 		if (isTempMonthFile && !monthFile.delete()) {
 			monthFile.deleteOnExit();

--- a/src/main/java/ui/export/TempFiles.java
+++ b/src/main/java/ui/export/TempFiles.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024. */
 package ui.export;
 
+import lombok.Getter;
 import ui.UserInterface;
 import ui.json.JSONHandler;
 
@@ -8,8 +9,10 @@ import java.io.File;
 
 class TempFiles implements AutoCloseable {
 
-	private final File globalFile;
-	private final File monthFile;
+	@Getter
+    private final File globalFile;
+	@Getter
+    private final File monthFile;
 
 	private final boolean isTempMonthFile;
 
@@ -19,15 +22,7 @@ class TempFiles implements AutoCloseable {
 		this.isTempMonthFile = isTempMonthFile;
 	}
 
-	public File getGlobalFile() {
-		return globalFile;
-	}
-
-	public File getMonthFile() {
-		return monthFile;
-	}
-
-	@Override
+    @Override
 	public void close() {
 		if (isTempMonthFile && !monthFile.delete()) {
 			monthFile.deleteOnExit();

--- a/src/main/java/ui/fileexplorer/FileChooser.java
+++ b/src/main/java/ui/fileexplorer/FileChooser.java
@@ -18,7 +18,7 @@ public final class FileChooser {
 	private static final String FORMAT = "%s_%s 20%s";
 
 	public static String getDefaultFileName(UserInterface parentUI) {
-		return FORMAT.formatted(JSONHandler.getGlobalSettings().getNameUnderscoreFormat(), getGermanMonth(parentUI.getCurrentMonthNumber()),
+		return FORMAT.formatted(JSONHandler.getGlobalSettings().getNameUnderscoreFormat(), "%02d".formatted(parentUI.getCurrentMonthNumber()),
 				parentUI.getYear());
 	}
 
@@ -96,30 +96,6 @@ public final class FileChooser {
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * Gets the german name for a month from 1-12.
-	 * 
-	 * @param monthName The month number, from 1-12.
-	 * @return The name of the month.
-	 */
-	private static String getGermanMonth(int monthName) {
-		return switch (monthName) {
-		case 1 -> "Januar";
-		case 2 -> "Februar";
-		case 3 -> "März";
-		case 4 -> "April";
-		case 5 -> "Mai";
-		case 6 -> "Juni";
-		case 7 -> "Juli";
-		case 8 -> "August";
-		case 9 -> "September";
-		case 10 -> "Oktober";
-		case 11 -> "November";
-		case 12 -> "Dezember";
-		default -> "unbekannt";
-		};
 	}
 
 	private static JFileChooser getFileChooser(FileChooserType chooserType) {

--- a/src/main/java/ui/fileexplorer/FileChooser.java
+++ b/src/main/java/ui/fileexplorer/FileChooser.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.fileexplorer;
 
 import ui.UserInterface;

--- a/src/main/java/ui/json/Global.java
+++ b/src/main/java/ui/json/Global.java
@@ -3,10 +3,14 @@ package ui.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Global Settings stored in AppData files.
  */
+@Getter
+@Setter
 public class Global {
 	@JsonProperty("$schema")
 	private String schema;
@@ -32,62 +36,6 @@ public class Global {
 	}
 
 	// Constructors, Getters, and Setters
-
-	public String getSchema() {
-		return schema;
-	}
-
-	public void setSchema(String schema) {
-		this.schema = schema;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public int getStaffId() {
-		return staffId;
-	}
-
-	public void setStaffId(int staffId) {
-		this.staffId = staffId;
-	}
-
-	public String getDepartment() {
-		return department;
-	}
-
-	public void setDepartment(String department) {
-		this.department = department;
-	}
-
-	public String getWorkingTime() {
-		return workingTime;
-	}
-
-	public void setWorkingTime(String workingTime) {
-		this.workingTime = workingTime;
-	}
-
-	public double getWage() {
-		return wage;
-	}
-
-	public void setWage(double wage) {
-		this.wage = wage;
-	}
-
-	public String getWorkingArea() {
-		return workingArea;
-	}
-
-	public void setWorkingArea(String workingArea) {
-		this.workingArea = workingArea;
-	}
 
 	/**
 	 * Formats the name, e.g. "Firstname-middle Lastname", to be "Lastname,

--- a/src/main/java/ui/json/Global.java
+++ b/src/main/java/ui/json/Global.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/ui/json/JSONHandler.java
+++ b/src/main/java/ui/json/JSONHandler.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.json;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/main/java/ui/json/JSONHandler.java
+++ b/src/main/java/ui/json/JSONHandler.java
@@ -222,7 +222,7 @@ public final class JSONHandler {
 		global.setStaffId(1234567);
 		global.setDepartment("Fakultät für Informatik");
 		global.setWorkingTime("39:00");
-		global.setWage(13.25);
+		global.setWage(13.98);
 		global.setWorkingArea("ub");
 		saveGlobal(global);
 	}

--- a/src/main/java/ui/json/JSONHandler.java
+++ b/src/main/java/ui/json/JSONHandler.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024. */
 package ui.json;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -53,7 +54,7 @@ public final class JSONHandler {
 		createDefaultGlobalSettings();
 		createDefaultOtherGlobalSettings();
 		loadGlobal();
-		loadOtherSettings();
+		loadUiSettings();
 
 		cleanUp();
 	}
@@ -104,10 +105,10 @@ public final class JSONHandler {
 		}
 	}
 
-	private static void loadOtherSettings() {
-		ObjectMapper objectMapper = new ObjectMapper();
+	private static void loadUiSettings() {
+		ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		try {
-			uiSettings = objectMapper.readValue(getOtherSettingsFile(), UISettings.class);
+			uiSettings = objectMapper.readValue(getUiSettingsFile(), UISettings.class);
 		} catch (IOException e) {
 			ErrorHandler.showError("Error loading UI settings file", ERROR.formatted(e.getMessage()));
 		}
@@ -117,7 +118,7 @@ public final class JSONHandler {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
 		try {
-			objectMapper.writeValue(getOtherSettingsFile(), uiSettings);
+			objectMapper.writeValue(getUiSettingsFile(), uiSettings);
 			setUISettings(uiSettings);
 		} catch (IOException e) {
 			ErrorHandler.showError("Error saving UI settings file", ERROR.formatted(e.getMessage()));
@@ -220,25 +221,25 @@ public final class JSONHandler {
 		global.setName("Max Mustermann");
 		global.setStaffId(1234567);
 		global.setDepartment("Fakultät für Informatik");
-		global.setWorkingTime("40:00");
+		global.setWorkingTime("39:00");
 		global.setWage(13.25);
 		global.setWorkingArea("ub");
 		saveGlobal(global);
 	}
 
-	public static File getOtherSettingsFile() {
+	public static File getUiSettingsFile() {
 		return new File(configDir, UI_SETTINGS_FILE_NAME);
 	}
 
 	private static boolean otherSettingsFileExists() {
-		return getOtherSettingsFile().exists();
+		return getUiSettingsFile().exists();
 	}
 
 	public static void createDefaultOtherGlobalSettings() {
 		if (otherSettingsFileExists())
 			return;
 		try {
-			File f = getOtherSettingsFile();
+			File f = getUiSettingsFile();
 			File folder = new File(configDir);
 			if (!folder.exists() && !folder.mkdirs()) {
 				// Show error in main and return using catch block
@@ -255,6 +256,10 @@ public final class JSONHandler {
 
 		UISettings settings = new UISettings();
 		settings.setAddSignature(false);
+		settings.setAddVacationEntry(false);
+		settings.setUseYYYY(false);
+		settings.setUseGermanMonths(false);
+		settings.setWarnOnHoursMismatch(true);
 		saveUISettings(settings);
 	}
 

--- a/src/main/java/ui/json/Month.java
+++ b/src/main/java/ui/json/Month.java
@@ -19,7 +19,7 @@ public class Month {
 	private int year;
 
 	@JsonProperty("month")
-	private int monthNr;
+	private int month;
 
 	@JsonProperty("pred_transfer")
 	private String predTransfer;
@@ -48,11 +48,21 @@ public class Month {
 
 	// Getters and Setters for Month class fields
 
-	public int getMonth() {
-		return monthNr;
-	}
-
-	public void setMonth(int month) {
-		this.monthNr = month;
+	public String getGermanName() {
+		return switch (month) {
+			case 1 -> "Januar";
+			case 2 -> "Februar";
+			case 3 -> "März";
+			case 4 -> "April";
+			case 5 -> "Mai";
+			case 6 -> "Juni";
+			case 7 -> "Juli";
+			case 8 -> "August";
+			case 9 -> "September";
+			case 10 -> "Oktober";
+			case 11 -> "November";
+			case 12 -> "Dezember";
+			default -> "null";
+		};
 	}
 }

--- a/src/main/java/ui/json/Month.java
+++ b/src/main/java/ui/json/Month.java
@@ -9,23 +9,32 @@ import lombok.Setter;
 import java.util.List;
 
 @JsonSerialize(using = MonthSerializer.class)
-@Getter
-@Setter
 public class Month {
 
 	@JsonProperty("$schema")
+	@Getter
+	@Setter
 	private String schema;
 
+	@Getter
+	@Setter
 	private int year;
 
 	@JsonProperty("month")
-	private int month;
+	private int monthNr;
 
 	@JsonProperty("pred_transfer")
+	@Getter
+	@Setter
 	private String predTransfer;
 
 	@JsonProperty("succ_transfer")
+	@Getter
+	@Setter
 	private String succTransfer;
+
+	@Getter
+	@Setter
 	private List<Entry> entries;
 
 	// Constructors, Getters, and Setters
@@ -48,8 +57,16 @@ public class Month {
 
 	// Getters and Setters for Month class fields
 
+	public void setMonth(int month) {
+		this.monthNr = month;
+	}
+
+	public int getMonth() {
+		return monthNr;
+	}
+
 	public String getGermanName() {
-		return switch (month) {
+		return switch (monthNr) {
 		case 1 -> "Januar";
 		case 2 -> "Februar";
 		case 3 -> "März";

--- a/src/main/java/ui/json/Month.java
+++ b/src/main/java/ui/json/Month.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +13,7 @@ import java.util.List;
 @Setter
 public class Month {
 
-    @JsonProperty("$schema")
+	@JsonProperty("$schema")
 	private String schema;
 
 	private int year;
@@ -35,8 +35,8 @@ public class Month {
 
 	// Nested class for individual entries
 	@Setter
-    @Getter
-    @JsonSerialize(using = EntrySerializer.class)
+	@Getter
+	@JsonSerialize(using = EntrySerializer.class)
 	public static class Entry {
 		private String action;
 		private int day;
@@ -44,25 +44,25 @@ public class Month {
 		private String end;
 		private String pause;
 		private boolean vacation;
-    }
+	}
 
 	// Getters and Setters for Month class fields
 
 	public String getGermanName() {
 		return switch (month) {
-			case 1 -> "Januar";
-			case 2 -> "Februar";
-			case 3 -> "März";
-			case 4 -> "April";
-			case 5 -> "Mai";
-			case 6 -> "Juni";
-			case 7 -> "Juli";
-			case 8 -> "August";
-			case 9 -> "September";
-			case 10 -> "Oktober";
-			case 11 -> "November";
-			case 12 -> "Dezember";
-			default -> "null";
+		case 1 -> "Januar";
+		case 2 -> "Februar";
+		case 3 -> "März";
+		case 4 -> "April";
+		case 5 -> "Mai";
+		case 6 -> "Juni";
+		case 7 -> "Juli";
+		case 8 -> "August";
+		case 9 -> "September";
+		case 10 -> "Oktober";
+		case 11 -> "November";
+		case 12 -> "Dezember";
+		default -> "null";
 		};
 	}
 }

--- a/src/main/java/ui/json/Month.java
+++ b/src/main/java/ui/json/Month.java
@@ -3,13 +3,17 @@ package ui.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @JsonSerialize(using = MonthSerializer.class)
+@Getter
+@Setter
 public class Month {
 
-	@JsonProperty("$schema")
+    @JsonProperty("$schema")
 	private String schema;
 
 	private int year;
@@ -30,7 +34,9 @@ public class Month {
 	}
 
 	// Nested class for individual entries
-	@JsonSerialize(using = EntrySerializer.class)
+	@Setter
+    @Getter
+    @JsonSerialize(using = EntrySerializer.class)
 	public static class Entry {
 		private String action;
 		private int day;
@@ -38,75 +44,9 @@ public class Month {
 		private String end;
 		private String pause;
 		private boolean vacation;
-
-		// Getters, and Setters
-
-		public String getAction() {
-			return action;
-		}
-
-		public void setAction(String action) {
-			this.action = action;
-		}
-
-		public int getDay() {
-			return day;
-		}
-
-		public void setDay(int day) {
-			this.day = day;
-		}
-
-		public String getStart() {
-			return start;
-		}
-
-		public void setStart(String start) {
-			this.start = start;
-		}
-
-		public String getEnd() {
-			return end;
-		}
-
-		public void setEnd(String end) {
-			this.end = end;
-		}
-
-		public String getPause() {
-			return pause;
-		}
-
-		public void setPause(String pause) {
-			this.pause = pause;
-		}
-
-		public boolean isVacation() {
-			return vacation;
-		}
-
-		public void setVacation(boolean vacation) {
-			this.vacation = vacation;
-		}
-	}
+    }
 
 	// Getters and Setters for Month class fields
-
-	public String getSchema() {
-		return schema;
-	}
-
-	public void setSchema(String schema) {
-		this.schema = schema;
-	}
-
-	public int getYear() {
-		return year;
-	}
-
-	public void setYear(int year) {
-		this.year = year;
-	}
 
 	public int getMonth() {
 		return monthNr;
@@ -114,29 +54,5 @@ public class Month {
 
 	public void setMonth(int month) {
 		this.monthNr = month;
-	}
-
-	public String getPredTransfer() {
-		return predTransfer;
-	}
-
-	public void setPredTransfer(String predTransfer) {
-		this.predTransfer = predTransfer;
-	}
-
-	public String getSuccTransfer() {
-		return succTransfer;
-	}
-
-	public void setSuccTransfer(String succTransfer) {
-		this.succTransfer = succTransfer;
-	}
-
-	public List<Entry> getEntries() {
-		return entries;
-	}
-
-	public void setEntries(List<Entry> entries) {
-		this.entries = entries;
 	}
 }

--- a/src/main/java/ui/json/UISettings.java
+++ b/src/main/java/ui/json/UISettings.java
@@ -1,12 +1,19 @@
 /* Licensed under MIT 2024. */
 package ui.json;
 
+import lombok.Getter;
+import lombok.Setter;
 import ui.fileexplorer.FileChooserType;
 
 import java.io.File;
 
+@Getter
+@Setter
 public class UISettings {
 	private boolean addSignature;
+	private boolean addVacationEntry;
+	private boolean useYYYY;
+	private boolean warnWhenNotPerfectTime;
 	private String monthPath;
 	private String texPath;
 	private String pdfPath;
@@ -17,6 +24,9 @@ public class UISettings {
 
 	public UISettings(UISettings uiSettings) {
 		this.addSignature = uiSettings.addSignature;
+		this.addVacationEntry = uiSettings.addVacationEntry;
+		this.useYYYY = uiSettings.useYYYY;
+		this.warnWhenNotPerfectTime = uiSettings.warnWhenNotPerfectTime;
 		this.monthPath = uiSettings.monthPath;
 		this.texPath = uiSettings.texPath;
 		this.pdfPath = uiSettings.pdfPath;
@@ -24,34 +34,14 @@ public class UISettings {
 
 	// Constructors, Getters, and Setters
 
-	public boolean getAddSignature() {
-		return addSignature;
-	}
-
-	public void setAddSignature(boolean addSignature) {
-		this.addSignature = addSignature;
-	}
-
-	public String getMonthPath() {
-		return monthPath;
-	}
-
 	public void setMonthPath(String openMonthPath) {
 		this.monthPath = openMonthPath;
 		save();
 	}
 
-	public String getTexPath() {
-		return texPath;
-	}
-
 	public void setTexPath(String texPath) {
 		this.texPath = texPath;
 		save();
-	}
-
-	public String getPdfPath() {
-		return pdfPath;
 	}
 
 	public void setPdfPath(String pdfPath) {

--- a/src/main/java/ui/json/UISettings.java
+++ b/src/main/java/ui/json/UISettings.java
@@ -1,6 +1,7 @@
 /* Licensed under MIT 2024. */
 package ui.json;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import lombok.Getter;
 import lombok.Setter;
 import ui.fileexplorer.FileChooserType;
@@ -10,10 +11,11 @@ import java.io.File;
 @Getter
 @Setter
 public class UISettings {
-	private boolean addSignature;
-	private boolean addVacationEntry;
-	private boolean useYYYY;
-	private boolean warnWhenNotPerfectTime;
+	private boolean addSignature = true;
+	private boolean addVacationEntry = false;
+	private boolean useYYYY = false;
+	private boolean useGermanMonths = false;
+	private boolean warnOnHoursMismatch = true;
 	private String monthPath;
 	private String texPath;
 	private String pdfPath;
@@ -26,7 +28,8 @@ public class UISettings {
 		this.addSignature = uiSettings.addSignature;
 		this.addVacationEntry = uiSettings.addVacationEntry;
 		this.useYYYY = uiSettings.useYYYY;
-		this.warnWhenNotPerfectTime = uiSettings.warnWhenNotPerfectTime;
+		this.useGermanMonths = uiSettings.useGermanMonths;
+		this.warnOnHoursMismatch = uiSettings.warnOnHoursMismatch;
 		this.monthPath = uiSettings.monthPath;
 		this.texPath = uiSettings.texPath;
 		this.pdfPath = uiSettings.pdfPath;

--- a/src/main/java/ui/json/UISettings.java
+++ b/src/main/java/ui/json/UISettings.java
@@ -1,7 +1,6 @@
-/* Licensed under MIT 2024. */
+/* Licensed under MIT 2024-2025. */
 package ui.json;
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import lombok.Getter;
 import lombok.Setter;
 import ui.fileexplorer.FileChooserType;


### PR DESCRIPTION
Hello! I've been working on some bug fixes that I missed and some new options, since Algo and Programming want different things on their timesheets. These changed only affect the UI code, though some of these features ought to be added to the CLI as well.

### Development
- Added Lombok

### Fixes
- Time updates when opening new file
- Month and year are now properly determined when exporting
- Minor visual changes

### New Settings
- Explicitly add vacation entries as entries
- Use 4 digit year in the day column
- Use german month names (instead of numbers) when exporting
- Warn when too few / too many hours worked. This affects the visual clues as well as a pop-up warning when exporting to Tex or PDF

### Other new features
- Several visual clues when you worked overtime, so you don't accidentally miss it.
- The top 3 new settings are dependent on where you send in the time sheets, there are buttons for the Algo and Proggen Settings for quick switching