### PR TITLE
Feature/UI f/new hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Yes, you can drag and drop your month.json files into the generator.
 The files can be compiled to tex or directly compiled to a pdf.
 
 #### To open a file with the UI from the command line, you can type `$ java -jar TimeSheetGenerator.jar /path/to/month.json` to open the specified file with the TimesheetGenerator UI.
+#### The TimesheetGenerator also supports "Open with..." with Windows (and probably other OS), but be cautions if you want to open every JSON file with the TimesheetGenerator.
 
 ### User Interface: Images
 
@@ -31,6 +32,24 @@ Adding a new entry to the timesheet:<br/>
 
 Editing the global settings:<br/>
 <img src="/examples/ui/ui_global_settings.png" alt="Image of the Edit Global Settings Dialog" width="80%">
+
+## Hotkeys
+
+### There are Hotkeys now. They are as follows:
+
+| Hotkey                                   | Feature                                             |
+|------------------------------------------|-----------------------------------------------------|
+| Ctrl S                                   | Saves the file to JSON                              |
+| Ctrl Shift S                             | Saves the file to JSON with a prompt for a new file |
+| Ctrl A                                   | Add a new entry                                     |
+| Ctrl D                                   | Duplicate the selected entry                        |
+| Ctrl E                                   | Exports to PDF                                      |
+| Ctrl P                                   | Same as Ctrl E, synonym                             |
+| Ctrl S                                   | Compiles to LaTeX                                   |
+| Ctrl N                                   | Opens a new file                                    |
+| Ctrl O                                   | Opens an existing file                              |
+
+### The Hotkey for Ctrl A may change in the future, when operations on multiple list entries are supported, and may then be used for select all.
 
 ## Command Line Execution
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Yes, you can drag and drop your month.json files into the generator.
 The files can be compiled to tex or directly compiled to a pdf.
 
 #### To open a file with the UI from the command line, you can type `$ java -jar TimeSheetGenerator.jar /path/to/month.json` to open the specified file with the TimesheetGenerator UI.
-#### The TimesheetGenerator also supports "Open with..." with Windows (and probably other OS), but be cautions if you want to open every JSON file with the TimesheetGenerator.
+#### The TimesheetGenerator also supports "Open with..." with Windows (and probably other OS), but be cautious if you want to open every JSON file with the TimesheetGenerator.
 
 ### User Interface: Images
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ Editing the global settings:<br/>
 
 ### There are Hotkeys now. They are as follows:
 
-| Hotkey                                   | Feature                                             |
-|------------------------------------------|-----------------------------------------------------|
-| Ctrl S                                   | Saves the file to JSON                              |
-| Ctrl Shift S                             | Saves the file to JSON with a prompt for a new file |
-| Ctrl A                                   | Add a new entry                                     |
-| Ctrl D                                   | Duplicate the selected entry                        |
-| Ctrl E                                   | Exports to PDF                                      |
-| Ctrl P                                   | Same as Ctrl E, synonym                             |
-| Ctrl S                                   | Compiles to LaTeX                                   |
-| Ctrl N                                   | Opens a new file                                    |
-| Ctrl O                                   | Opens an existing file                              |
+| Hotkey       | Feature                                             |
+|--------------|-----------------------------------------------------|
+| Ctrl S       | Saves the file to JSON                              |
+| Ctrl Shift S | Saves the file to JSON with a prompt for a new file |
+| Ctrl A       | Add a new entry                                     |
+| Ctrl D       | Duplicate the selected entry                        |
+| Ctrl E       | Exports to PDF                                      |
+| Ctrl P       | Same as Ctrl E, synonym ("print")                   |
+| Ctrl T       | Compiles to LaTeX                                   |
+| Ctrl N       | Opens a new file                                    |
+| Ctrl O       | Opens an existing file                              |
 
 ### The Hotkey for Ctrl A may change in the future, when operations on multiple list entries are supported, and may then be used for select all.
 

--- a/src/main/java/checker/MiLoGChecker.java
+++ b/src/main/java/checker/MiLoGChecker.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2024. */
+/* Licensed under MIT 2023-2025. */
 package checker;
 
 import checker.holiday.GermanState;
@@ -170,11 +170,10 @@ public class MiLoGChecker implements IChecker {
 		for (Map.Entry<LocalDate, TimeSpan[]> mapEntry : workingDays.entrySet()) {
 			for (TimeSpan[] pauseRule : PAUSE_RULES) {
 
-				// Checks whether time of entry is greater than or equal pause rule "activation"
+				// Checks whether time of entry is greater than pause rule "activation"
 				// time
 				// and pause time is less than the needed time.
-				if (mapEntry.getValue()[0].compareTo(pauseRule[0]) >= 0 && mapEntry.getValue()[1].compareTo(pauseRule[1]) < 0) {
-
+				if (mapEntry.getValue()[0].compareTo(pauseRule[0]) > 0 && mapEntry.getValue()[1].compareTo(pauseRule[1]) < 0) {
 					errors.add(new CheckerError(MiLoGCheckerErrorMessageProvider.TIME_PAUSE, mapEntry.getKey()));
 					result = CheckerReturn.INVALID;
 					break;

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -51,29 +51,13 @@ public class ActionBar extends JPanel {
 
 		this.add(buttonPanel, BorderLayout.WEST);
 
-		addButton.addActionListener(e -> {
-			if (this.parentUi.isSpaceForNewEntry()) {
-				DialogHelper.showEntryDialog(this.parentUi, "Add Entry");
-			} else {
-				ErrorHandler.showError("Entry limit reached", "You have reached the maximum of %d entries".formatted(UserInterface.MAX_ENTRIES));
-			}
-		});
+		addButton.addActionListener(e -> addEntryButtonClicked());
 		duplicateButton.addActionListener(l -> this.parentUi.duplicateSelectedListEntry());
 		removeButton.addActionListener(l -> this.parentUi.removeSelectedListEntry());
 		editButton.addActionListener(l -> this.parentUi.editSelectedListEntry());
 
-		compileButton.addActionListener(l -> {
-			if (hourMismatchCheck()) {
-				return;
-			}
-			FileExporter.printTex(this.parentUi);
-		});
-		printButton.addActionListener(l -> {
-			if (hourMismatchCheck()) {
-				return;
-			}
-			FileExporter.printPDF(this.parentUi);
-		});
+		compileButton.addActionListener(l -> compileTexButtonClicked());
+		printButton.addActionListener(l -> exportPdfButtonClicked());
 
 		hoursWorkedLabel = new JLabel();
 		fontNormal = hoursWorkedLabel.getFont().deriveFont(18f);
@@ -86,6 +70,50 @@ public class ActionBar extends JPanel {
 	private boolean hourMismatchCheck() {
 		return (JSONHandler.getUISettings().isWarnOnHoursMismatch() && parentUi.hasWorkedHoursMismatch()
 				&& !parentUi.showOKCancelDialog("Hours mismatch", "Warning: The worked hours do not match the target working hours. Do you want to continue?"));
+	}
+
+	/**
+	 * This is the method that is called when the tex button is clicked.
+	 * First, it checks for a mismatch in worked time, then it prompts the
+	 * user to save the file as LaTeX.
+	 * <br/>
+	 * Exposed functionality because of hotkeys.
+	 */
+	public void compileTexButtonClicked() {
+		if (hourMismatchCheck()) {
+			return;
+		}
+		FileExporter.printTex(this.parentUi);
+	}
+
+	/**
+	 * This is the method that is called when the print button is clicked.
+	 * First, it checks for a mismatch in worked time, then it prompts the
+	 * user to save the file as a pdf.
+	 * <br/>
+	 * Exposed functionality because of hotkeys.
+	 */
+	public void exportPdfButtonClicked() {
+		if (hourMismatchCheck()) {
+			return;
+		}
+		FileExporter.printPDF(this.parentUi);
+	}
+
+	/**
+	 * This is the method that is called when the add entry button is clicked.
+	 * Simply calls upon the current {@link UserInterface} to add a new entry,
+	 * after performing a check to see if there is space and showing an
+	 * appropriate dialog if not.
+	 * <br/>
+	 * Exposed functionality because of hotkeys.
+	 */
+	public void addEntryButtonClicked() {
+		if (this.parentUi.isSpaceForNewEntry()) {
+			DialogHelper.showEntryDialog(this.parentUi, "Add Entry");
+		} else {
+			ErrorHandler.showError("Entry limit reached", "You have reached the maximum of %d entries".formatted(UserInterface.MAX_ENTRIES));
+		}
 	}
 
 	/**

--- a/src/main/java/ui/ActionBar.java
+++ b/src/main/java/ui/ActionBar.java
@@ -73,10 +73,9 @@ public class ActionBar extends JPanel {
 	}
 
 	/**
-	 * This is the method that is called when the tex button is clicked.
-	 * First, it checks for a mismatch in worked time, then it prompts the
-	 * user to save the file as LaTeX.
-	 * <br/>
+	 * This is the method that is called when the tex button is clicked. First, it
+	 * checks for a mismatch in worked time, then it prompts the user to save the
+	 * file as LaTeX. <br/>
 	 * Exposed functionality because of hotkeys.
 	 */
 	public void compileTexButtonClicked() {
@@ -87,10 +86,9 @@ public class ActionBar extends JPanel {
 	}
 
 	/**
-	 * This is the method that is called when the print button is clicked.
-	 * First, it checks for a mismatch in worked time, then it prompts the
-	 * user to save the file as a pdf.
-	 * <br/>
+	 * This is the method that is called when the print button is clicked. First, it
+	 * checks for a mismatch in worked time, then it prompts the user to save the
+	 * file as a pdf. <br/>
 	 * Exposed functionality because of hotkeys.
 	 */
 	public void exportPdfButtonClicked() {
@@ -102,10 +100,9 @@ public class ActionBar extends JPanel {
 
 	/**
 	 * This is the method that is called when the add entry button is clicked.
-	 * Simply calls upon the current {@link UserInterface} to add a new entry,
-	 * after performing a check to see if there is space and showing an
-	 * appropriate dialog if not.
-	 * <br/>
+	 * Simply calls upon the current {@link UserInterface} to add a new entry, after
+	 * performing a check to see if there is space and showing an appropriate dialog
+	 * if not. <br/>
 	 * Exposed functionality because of hotkeys.
 	 */
 	public void addEntryButtonClicked() {

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -9,7 +9,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -220,6 +219,10 @@ public final class DialogHelper {
 
 		// Action listeners for buttons
 		makeEntryButton.addActionListener(e -> {
+			makeEntryButton.requestFocusInWindow();
+			for (int index : new int[] { INDEX_START_TIME, INDEX_END_TIME, INDEX_BREAK_TIME }) {
+				updateTimeFieldView(index, labels.length - 1, timeFields, errorLabels, durationSummaryValue, durationWarningLabel, vacationCheckBox);
+			}
 			if (makeEntryAction(parentUi, durationWarningLabel, actionTextField, timeFields, vacationCheckBox))
 				dialog.dispose();
 		});
@@ -291,7 +294,7 @@ public final class DialogHelper {
 	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextField actionTextField, JTextField[] timeFields,
 			JCheckBox vacationCheckBox) {
 		if (durationWarningLabel.getText().isBlank()) {
-			if ( actionTextField.getText().isBlank() || actionTextField.getForeground() != Color.BLACK) {
+			if (actionTextField.getText().isBlank() || actionTextField.getForeground() != Color.BLACK) {
 				durationWarningLabel.setText(ACTIVITY_MESSAGE);
 			}
 			// warning label is updated automatically when fields are edited
@@ -590,13 +593,12 @@ public final class DialogHelper {
 	}
 
 	public static void addEnterEscapeHotkeys(JDialog dialog, JButton okButton, JButton cancelButton) {
-		/* ----------  ENTER  ---------- */
+		/* ---------- ENTER ---------- */
 		dialog.getRootPane().setDefaultButton(okButton);
 
-		/* ----------  ESCAPE  ---------- */
+		/* ---------- ESCAPE ---------- */
 		KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
-		dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-				.put(escape, "cancel-dialog");
+		dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, "cancel-dialog");
 		dialog.getRootPane().getActionMap().put("cancel-dialog", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -6,8 +6,11 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.time.Duration;
@@ -50,7 +53,6 @@ public final class DialogHelper {
 		JDialog dialog = new JDialog();
 		dialog.setTitle(title);
 		dialog.setSize(600, 400);
-		dialog.setModal(true);
 		dialog.setLocationRelativeTo(null); // Center the dialog
 
 		// Labels for later
@@ -192,7 +194,7 @@ public final class DialogHelper {
 
 		row++;
 
-		// 7. Warning label for break time
+		// Warning label for break time
 		durationWarningLabel.setForeground(Color.RED);
 		gbc.gridx = 1;
 		gbc.gridy = row;
@@ -262,6 +264,9 @@ public final class DialogHelper {
 
 		dialog.add(panel);
 		dialog.setVisible(true);
+		addEnterEscapeHotkeys(dialog, makeEntryButton, cancelButton);
+		dialog.pack();
+		dialog.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
 	}
 
 	private static void discardChanges(TimesheetEntry entry, UserInterface parentUi, JDialog dialog) {
@@ -286,7 +291,7 @@ public final class DialogHelper {
 	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextField actionTextField, JTextField[] timeFields,
 			JCheckBox vacationCheckBox) {
 		if (durationWarningLabel.getText().isBlank()) {
-			if (actionTextField.getText().isBlank()) {
+			if ( actionTextField.getText().isBlank() || actionTextField.getForeground() != Color.BLACK) {
 				durationWarningLabel.setText(ACTIVITY_MESSAGE);
 			}
 			// warning label is updated automatically when fields are edited
@@ -582,6 +587,22 @@ public final class DialogHelper {
 				Toolkit.getDefaultToolkit().beep();
 			}
 		}
+	}
+
+	public static void addEnterEscapeHotkeys(JDialog dialog, JButton okButton, JButton cancelButton) {
+		/* ----------  ENTER  ---------- */
+		dialog.getRootPane().setDefaultButton(okButton);
+
+		/* ----------  ESCAPE  ---------- */
+		KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+		dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+				.put(escape, "cancel-dialog");
+		dialog.getRootPane().getActionMap().put("cancel-dialog", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				cancelButton.doClick();
+			}
+		});
 	}
 
 }

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -295,19 +295,7 @@ public final class DialogHelper {
 	private static boolean makeEntryAction(UserInterface parentUI, JLabel durationWarningLabel, JTextField actionTextField, JTextField[] timeFields,
 			JCheckBox vacationCheckBox) {
 		if (durationWarningLabel.getText().isBlank()) {
-			if (actionTextField.getText().isBlank() || actionTextField.getForeground() != Color.BLACK) {
-				durationWarningLabel.setText(ACTIVITY_MESSAGE);
-			}
-			// warning label is updated automatically when fields are edited
-			if (timeFields[INDEX_DAY].getText().isBlank() || timeFields[INDEX_DAY].getText().equals(DAY_PLACEHOLDER)) {
-				durationWarningLabel.setText("You need to enter a day!");
-			}
-			if (timeFields[INDEX_START_TIME].getText().isBlank() || timeFields[INDEX_START_TIME].getText().equals(TIME_PLACEHOLDER)) {
-				durationWarningLabel.setText("You need to enter a start time!");
-			}
-			if (timeFields[INDEX_END_TIME].getText().isBlank() || timeFields[INDEX_END_TIME].getText().equals(TIME_PLACEHOLDER)) {
-				durationWarningLabel.setText("You need to enter an end time!");
-			}
+			validateDurationFields(durationWarningLabel, actionTextField, timeFields);
 		}
 
 		if (!durationWarningLabel.getText().isBlank()) {
@@ -349,6 +337,33 @@ public final class DialogHelper {
 			checkStartEndTime(timeFields[INDEX_START_TIME], timeFields[INDEX_END_TIME]);
 			updateDurationSummary(durationSummaryValue, timeFields[INDEX_START_TIME], timeFields[INDEX_END_TIME], timeFields[INDEX_BREAK_TIME],
 					durationWarningLabel, vacationCheckBox);
+		}
+	}
+
+	/**
+	 * Validates the activity and time fields' content when attempting to create an
+	 * entry. Writes the error message to the warning label specified as
+	 * durationWarningLabel.
+	 * 
+	 * @param durationWarningLabel the warning label for the entry dialog.
+	 * @param actionTextField      The text field for the activity.
+	 * @param timeFields           The fields where day and times are stored.
+	 *                             Locations in the array must match the global
+	 *                             constants for INDEX_...
+	 */
+	private static void validateDurationFields(JLabel durationWarningLabel, JTextField actionTextField, JTextField[] timeFields) {
+		if (actionTextField.getText().isBlank() || actionTextField.getForeground() != Color.BLACK) {
+			durationWarningLabel.setText(ACTIVITY_MESSAGE);
+		}
+		// warning label is updated automatically when fields are edited
+		if (timeFields[INDEX_DAY].getText().isBlank() || timeFields[INDEX_DAY].getText().equals(DAY_PLACEHOLDER)) {
+			durationWarningLabel.setText("You need to enter a day!");
+		}
+		if (timeFields[INDEX_START_TIME].getText().isBlank() || timeFields[INDEX_START_TIME].getText().equals(TIME_PLACEHOLDER)) {
+			durationWarningLabel.setText("You need to enter a start time!");
+		}
+		if (timeFields[INDEX_END_TIME].getText().isBlank() || timeFields[INDEX_END_TIME].getText().equals(TIME_PLACEHOLDER)) {
+			durationWarningLabel.setText("You need to enter an end time!");
 		}
 	}
 

--- a/src/main/java/ui/DialogHelper.java
+++ b/src/main/java/ui/DialogHelper.java
@@ -32,6 +32,7 @@ public final class DialogHelper {
 	static final Pattern TIME_PATTERN = Pattern.compile("^(\\d{1,2}):(\\d{2})$");
 	static final Pattern TIME_PATTERN_SMALL = Pattern.compile("^(\\d{1,2})$");
 	static final Pattern TIME_PATTERN_SEMI_SMALL = Pattern.compile("^(\\d{1,2}):(\\d)$");
+	private static final String TIME_FORMAT = "%02d:%02d";
 
 	private static final int MAX_TEXT_LENGTH_ACTIVITY = 30;
 	private static final int MIN_BREAK_SIX_HOURS = 30;
@@ -409,7 +410,6 @@ public final class DialogHelper {
 			timeField.setText(text);
 		} else if (TIME_PATTERN_SEMI_SMALL.matcher(text).matches()) {
 			text += "0";
-			timeField.setText(text);
 		}
 
 		Matcher matcher = TIME_PATTERN.matcher(text);
@@ -421,6 +421,7 @@ public final class DialogHelper {
 			} else {
 				errorLabel.setText("Invalid time");
 			}
+			timeField.setText(TIME_FORMAT.formatted(hours, minutes));
 		} else {
 			errorLabel.setText("Invalid time");
 		}
@@ -534,7 +535,8 @@ public final class DialogHelper {
 		if (timeStr == null)
 			return LocalTime.of(0, 0);
 		try {
-			return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("H:mm"));
+			String time = timeStr.replace('.', ':');
+			return LocalTime.parse(time, DateTimeFormatter.ofPattern("H:mm"));
 		} catch (DateTimeParseException e) {
 			return LocalTime.of(0, 0);
 		}

--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -28,7 +28,6 @@ public final class GlobalSettingsDialog {
 		JDialog dialog = new JDialog();
 		dialog.setTitle("Global Settings");
 		dialog.setSize(690, 525);
-		dialog.setModal(true);
 		dialog.setLocationRelativeTo(null); // Center the dialog
 
 		Global globalSettings = JSONHandler.getGlobalSettings();
@@ -182,6 +181,9 @@ public final class GlobalSettingsDialog {
 		scrollPanel.getVerticalScrollBar().setUnitIncrement(SCROLL_SENSITIVITY);
 		dialog.add(scrollPanel);
 		dialog.setVisible(true);
+		DialogHelper.addEnterEscapeHotkeys(dialog, saveButton, cancelButton);
+		dialog.pack();
+		dialog.setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
 	}
 
 	/**

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -134,7 +134,7 @@ public class UserInterface {
 		fileOptionSave.addActionListener(e -> saveFile(currentOpenFile));
 		fileOptionSaveAs.addActionListener(e -> saveFileAs());
 
-		addHotkeys();
+		addHotkeys(itemList);
 
 		// Show Frame
 		frame.setVisible(true);
@@ -160,8 +160,9 @@ public class UserInterface {
 	 * <li>Ctrl E - Exports to PDF</li>
 	 * <li>Ctrl P - Same as Ctrl E, synonym</li>
 	 * <li>Ctrl S - Compiles to LaTeX</li>
+	 * @param itemList The main item list, this will override the Ctrl + A keybind to add entry as well.
 	 */
-	private void addHotkeys() {
+	private void addHotkeys(final JList<?> itemList) {
 		// Ctrl + S to save
 		KeyStroke saveKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
 		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(saveKeyStroke, "saveAction");
@@ -173,15 +174,24 @@ public class UserInterface {
 		});
 
 		// Ctrl + A to add a new entry
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
-				"addEntryAction");
-		frame.getRootPane().getActionMap().put("addEntryAction", new AbstractAction() {
+		KeyStroke addEntryKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
+		// Replace the default “selectAll” for the list itself
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(addEntryKeyStroke, "addEntryAction");
+
+		for (var key : itemList.getInputMap().allKeys()) {
+			System.out.println("Key: " + key + " --- " + itemList.getInputMap().get(key));
+		}
+
+		AbstractAction addEntryAction = new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				System.out.println("DEBUG");
 				buttonActionBar.addEntryButtonClicked();
 			}
-		});
+		};
+		frame.getRootPane().getActionMap().put("addEntryAction", addEntryAction);
+		// Override selectAll action
+		itemList.getActionMap().put("selectAll", addEntryAction);
 
 		// Ctrl + D to duplicate the selected entry
 		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
@@ -204,6 +214,7 @@ public class UserInterface {
 		frame.getRootPane().getActionMap().put("exportAction", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				System.out.println("DEBUG PDF");
 				buttonActionBar.exportPdfButtonClicked();
 			}
 		});

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -148,19 +148,22 @@ public class UserInterface {
 				}
 			}
 		});
+		itemList.requestFocusInWindow();
 	}
 
 	/**
 	 * Adds all hotkeys to the current {@link UserInterface#frame}. Most Hotkeys
-	 * just perform actions from buttons in the {@link ActionBar}.
-	 * Current Hotkeys are:
+	 * just perform actions from buttons in the {@link ActionBar}. Current Hotkeys
+	 * are:
 	 * <li>Ctrl S - Saves the file to JSON</li>
 	 * <li>Ctrl A - Add a new entry</li>
 	 * <li>Ctrl D - Duplicate the selected entry</li>
 	 * <li>Ctrl E - Exports to PDF</li>
 	 * <li>Ctrl P - Same as Ctrl E, synonym</li>
 	 * <li>Ctrl S - Compiles to LaTeX</li>
-	 * @param itemList The main item list, this will override the Ctrl + A keybind to add entry as well.
+	 * 
+	 * @param itemList The main item list, this will override the Ctrl + A keybind
+	 *                 to add entry as well.
 	 */
 	private void addHotkeys(final JList<?> itemList) {
 		// Ctrl + S to save
@@ -176,27 +179,30 @@ public class UserInterface {
 		// Ctrl + A to add a new entry
 		KeyStroke addEntryKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
 		// Replace the default “selectAll” for the list itself
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(addEntryKeyStroke, "addEntryAction");
-
-		for (var key : itemList.getInputMap().allKeys()) {
-			System.out.println("Key: " + key + " --- " + itemList.getInputMap().get(key));
-		}
-
 		AbstractAction addEntryAction = new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				System.out.println("DEBUG");
 				buttonActionBar.addEntryButtonClicked();
 			}
 		};
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(addEntryKeyStroke, "addEntryAction");
 		frame.getRootPane().getActionMap().put("addEntryAction", addEntryAction);
 		// Override selectAll action
 		itemList.getActionMap().put("selectAll", addEntryAction);
 
+		// Remove selected entry with backspace key
+		itemList.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0), "removeListEntry");
+		itemList.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "removeListEntry");
+		itemList.getActionMap().put("removeListEntry", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				removeSelectedListEntry();
+			}
+		});
+
 		// Ctrl + D to duplicate the selected entry
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
-				"duplicateEntryAction");
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()), "duplicateEntryAction");
 		frame.getRootPane().getActionMap().put("duplicateEntryAction", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -205,24 +211,20 @@ public class UserInterface {
 		});
 
 		// Ctrl + E and Ctrl + P should both print (export) to PDF
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
-				"exportAction");
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
-				"exportAction");
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()), "exportAction");
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()), "exportAction");
 		frame.getRootPane().getActionMap().put("exportAction", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				System.out.println("DEBUG PDF");
 				buttonActionBar.exportPdfButtonClicked();
 			}
 		});
 
 		// Ctrl + T to compile to LaTeX
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
-				"compileAction");
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()), "compileAction");
 		frame.getRootPane().getActionMap().put("compileAction", new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -162,7 +162,7 @@ public class UserInterface {
 	 * <li>Ctrl D - Duplicate the selected entry</li>
 	 * <li>Ctrl E - Exports to PDF</li>
 	 * <li>Ctrl P - Same as Ctrl E, synonym</li>
-	 * <li>Ctrl S - Compiles to LaTeX</li>
+	 * <li>Ctrl T - Compiles to LaTeX</li>
 	 * <li>Ctrl N - Opens a new file</li>
 	 * <li>Ctrl O - Opens an existing file</li>
 	 *

--- a/src/main/java/ui/UserInterface.java
+++ b/src/main/java/ui/UserInterface.java
@@ -134,16 +134,7 @@ public class UserInterface {
 		fileOptionSave.addActionListener(e -> saveFile(currentOpenFile));
 		fileOptionSaveAs.addActionListener(e -> saveFileAs());
 
-		// Add Ctrl + S to save
-
-		KeyStroke saveKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
-		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(saveKeyStroke, "saveAction");
-		frame.getRootPane().getActionMap().put("saveAction", new AbstractAction() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				saveFile(currentOpenFile);
-			}
-		});
+		addHotkeys();
 
 		// Show Frame
 		frame.setVisible(true);
@@ -155,6 +146,76 @@ public class UserInterface {
 					frame.dispose();
 					System.exit(0);
 				}
+			}
+		});
+	}
+
+	/**
+	 * Adds all hotkeys to the current {@link UserInterface#frame}. Most Hotkeys
+	 * just perform actions from buttons in the {@link ActionBar}.
+	 * Current Hotkeys are:
+	 * <li>Ctrl S - Saves the file to JSON</li>
+	 * <li>Ctrl A - Add a new entry</li>
+	 * <li>Ctrl D - Duplicate the selected entry</li>
+	 * <li>Ctrl E - Exports to PDF</li>
+	 * <li>Ctrl P - Same as Ctrl E, synonym</li>
+	 * <li>Ctrl S - Compiles to LaTeX</li>
+	 */
+	private void addHotkeys() {
+		// Ctrl + S to save
+		KeyStroke saveKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx());
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(saveKeyStroke, "saveAction");
+		frame.getRootPane().getActionMap().put("saveAction", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				saveFile(currentOpenFile);
+			}
+		});
+
+		// Ctrl + A to add a new entry
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
+				"addEntryAction");
+		frame.getRootPane().getActionMap().put("addEntryAction", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				buttonActionBar.addEntryButtonClicked();
+			}
+		});
+
+		// Ctrl + D to duplicate the selected entry
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
+				"duplicateEntryAction");
+		frame.getRootPane().getActionMap().put("duplicateEntryAction", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				duplicateSelectedListEntry();
+			}
+		});
+
+		// Ctrl + E and Ctrl + P should both print (export) to PDF
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
+				"exportAction");
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
+				"exportAction");
+		frame.getRootPane().getActionMap().put("exportAction", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				buttonActionBar.exportPdfButtonClicked();
+			}
+		});
+
+		// Ctrl + T to compile to LaTeX
+		frame.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),
+				"compileAction");
+		frame.getRootPane().getActionMap().put("compileAction", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				buttonActionBar.compileTexButtonClicked();
 			}
 		});
 	}

--- a/src/main/java/ui/fileexplorer/FileChooser.java
+++ b/src/main/java/ui/fileexplorer/FileChooser.java
@@ -92,6 +92,14 @@ public final class FileChooser {
 
 		if (userSelection == JFileChooser.APPROVE_OPTION) {
 			File fileToSave = fileChooser.getSelectedFile();
+			if (!fileToSave.getName().endsWith(".%s".formatted(extension))) {
+				String path = fileToSave.getAbsolutePath();
+				if (!fileToSave.getName().endsWith(".")) {
+					// Add dot
+					path = path + ".";
+				}
+				fileToSave = new File(path + extension);
+			}
 			if (fileToSave.exists()) {
 				int result = JOptionPane.showConfirmDialog(null, "The file already exists. Do you want to override it?", "Existing file",
 						JOptionPane.YES_NO_OPTION);


### PR DESCRIPTION
Hello there! We have a few new hotkeys and bugfixes to merge.

---

## New features

### Hotkeys

Some features now have hotkeys; currently, they are only listed in the README (and Javadoc).

| Hotkey                                   | Feature                                             |
|------------------------------------------|-----------------------------------------------------|
| Ctrl S                                   | Saves the file to JSON                              |
| Ctrl Shift S                             | Saves the file to JSON with a prompt for a new file |
| Ctrl A                                   | Add a new entry                                     |
| Ctrl D                                   | Duplicate the selected entry                        |
| Ctrl E                                   | Exports to PDF                                      |
| Ctrl P                                   | Same as Ctrl E, synonym ("print")                             |
| Ctrl T                                   | Compiles to LaTeX                                   |
| Ctrl N                                   | Opens a new file                                    |
| Ctrl O                                   | Opens an existing file                              |

_The Hotkey for Ctrl A may change in the future, when operations on multiple list entries are supported, and may then be used for select all._

#### The Dialogs now also respond to Enter for OK and Escape for Cancel, and Entries can be deleted with either delete or backspace.

## Fixes

- When entering a time and using the dot character ('.') as delimiter, time is now properly parsed and processed, instead of defaulting to 00:00
- Fixed file ending not being enforced, so when the json file was saved as "temp", it previously did not automatically receive the file ending .json
- According to german labour law, the 30 minute break is only required when working past 6 hours, so the equals was removed in the check during export. Same for the 45 minute break and 9 hours.

## Planned for the future

- Support for Ctrl + C and Ctrl + V, across documents.
- Applying actions (like Delete, Copy) to multiple entries at once, which would probably reassign the Ctrl + A hotkey back to select all
- Same stuff as in the previous PR