### PR TITLE
Fixed Global Settings not getting saved

### DIFF
--- a/src/main/java/ui/GlobalSettingsDialog.java
+++ b/src/main/java/ui/GlobalSettingsDialog.java
@@ -221,7 +221,7 @@ public final class GlobalSettingsDialog {
 			return false;
 
 		// Update globalSettings object
-		if (fields.length == 5) {
+		if (fields.length >= 5) {
 			globalSettings.setName(fields[0].getText());
 			globalSettings.setStaffId(Integer.parseInt(fields[1].getText()));
 			globalSettings.setDepartment(fields[2].getText());


### PR DESCRIPTION
oopsy, due to an old == check for amount of fields, saving the parts of global settings that go into the `global.json` file was broken.
The `==` has been changed to `>=`.